### PR TITLE
feat: make bip44 purpose and type const

### DIFF
--- a/hippod/cmd/root.go
+++ b/hippod/cmd/root.go
@@ -39,8 +39,8 @@ var ChainID string
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
-	// Set config for prefixes
-	consensus.SetWalletPrefix()
+	// Set config for wallet
+	consensus.SetWalletConfig()
 
 	encodingConfig := app.MakeEncodingConfig()
 	initClientCtx := client.Context{}.

--- a/types/consensus/wallet.go
+++ b/types/consensus/wallet.go
@@ -13,11 +13,18 @@ const (
 	ConsensusNodePubkeyPrefix = AddrPrefix + "valconspub"
 )
 
-// Set prefix of address and pubkey for general, validator and consensus node
-func SetWalletPrefix() {
+const (
+	BIP44Purpose  = 44
+	BIP44CoinType = 0
+)
+
+// Set prefix of address and pubkey for general, validator and consensus node.
+//
+// Set BIP44 path purpose and coin type.
+func SetWalletConfig() {
 	config := sdk.GetConfig()
-	config.SetPurpose(44)
-	config.SetCoinType(0)
+	config.SetPurpose(BIP44Purpose)
+	config.SetCoinType(BIP44CoinType)
 	config.SetBech32PrefixForAccount(AddrPrefix, PubkeyPrefix)
 	config.SetBech32PrefixForValidator(ValidatorAddrPrefix, ValidatorPubkeyPrefix)
 	config.SetBech32PrefixForConsensusNode(ConsensusNodeAddrPrefix, ConsensusNodePubkeyPrefix)


### PR DESCRIPTION
Every crucial constant value must be named and initialized with `const`.