### PR TITLE
feat: add policy to handle policy-related const

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"time"
 
 	cfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/cli"
@@ -53,8 +52,8 @@ const (
 
 	// FlagStakingBondDenom defines a flag to specify the staking token in the genesis file.
 	FlagStakingBondDenom = "staking-bond-denom"
-	blockTimeSec         = 6                                  // 5s of timeout_commit + 1s
-	unbondingPeriod      = 60 * 60 * 24 * 7 * 3 * time.Second // three weeks
+	blockTimeSec         = consensus.BlockTimeSec    // 5s of timeout_commit + 1s
+	unbondingPeriod      = consensus.UnbondingPeriod // three weeks
 )
 
 type printInfo struct {
@@ -200,21 +199,21 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	}
 
 	stakingGenState.Params.UnbondingTime = unbondingPeriod
-	stakingGenState.Params.MaxValidators = 50
+	stakingGenState.Params.MaxValidators = consensus.MaxValidators
 	stakingGenState.Params.BondDenom = consensus.DefaultHippoDenom
-	stakingGenState.Params.MinCommissionRate = sdk.NewDecWithPrec(5, 2)
+	stakingGenState.Params.MinCommissionRate = sdk.NewDecWithPrec(consensus.MinCommissionRate, 2)
 	appState[stakingtypes.ModuleName] = cdc.MustMarshalJSON(&stakingGenState)
 
 	var mintGenState minttypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[minttypes.ModuleName], &mintGenState); err != nil {
 		return nil, err
 	}
-	mintGenState.Minter = minttypes.InitialMinter(sdk.NewDecWithPrec(25, 2)) // 25% inflation
+	mintGenState.Minter = minttypes.InitialMinter(sdk.NewDecWithPrec(consensus.Minter, 2)) // 25% inflation
 	mintGenState.Params.MintDenom = consensus.DefaultHippoDenom
-	mintGenState.Params.InflationRateChange = sdk.NewDecWithPrec(20, 2) // 20%
-	mintGenState.Params.InflationMin = sdk.NewDecWithPrec(0, 2)         // 0%
-	mintGenState.Params.InflationMax = sdk.NewDecWithPrec(25, 2)        // 25%
-	mintGenState.Params.BlocksPerYear = uint64(60*60*24*365) / uint64(blockTimeSec)
+	mintGenState.Params.InflationRateChange = sdk.NewDecWithPrec(consensus.InflationRateChange, 2) // 20%
+	mintGenState.Params.InflationMin = sdk.NewDecWithPrec(consensus.InflationMin, 2)               // 0%
+	mintGenState.Params.InflationMax = sdk.NewDecWithPrec(consensus.InflationMax, 2)               // 25%
+	mintGenState.Params.BlocksPerYear = consensus.BlocksPerYear
 	appState[minttypes.ModuleName] = cdc.MustMarshalJSON(&mintGenState)
 
 	var distrGenState distrtypes.GenesisState
@@ -228,11 +227,11 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	if err := cdc.UnmarshalJSON(appState[govtypes.ModuleName], &govGenState); err != nil {
 		return nil, err
 	}
-	minDepositTokens := sdk.TokensFromConsensusPower(100_000, sdk.DefaultPowerReduction) // 100,000 HP
+	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction) // 100,000 HP
 	govGenState.Params.MinDeposit = sdk.Coins{sdk.NewCoin(consensus.DefaultHippoDenom, minDepositTokens)}
-	maxDepositPeriod := 60 * 60 * 24 * 14 * time.Second // 14 days
+	maxDepositPeriod := consensus.MaxDepositPeriod // 14 days
 	govGenState.Params.MaxDepositPeriod = &maxDepositPeriod
-	votingPeriod := 60 * 60 * 24 * 3 * time.Second // 3 days (shortened voting period)
+	votingPeriod := consensus.VotingPeriod
 	govGenState.Params.VotingPeriod = &votingPeriod
 	appState[govtypes.ModuleName] = cdc.MustMarshalJSON(&govGenState)
 
@@ -240,18 +239,18 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	if err := cdc.UnmarshalJSON(appState[crisistypes.ModuleName], &crisisGenState); err != nil {
 		return nil, err
 	}
-	constantFee := sdk.TokensFromConsensusPower(1_000_000, sdk.DefaultPowerReduction)  // 1,000,000 HP
-	crisisGenState.ConstantFee = sdk.NewCoin(consensus.DefaultHippoDenom, constantFee) // Spend 1,000,000 HP for invariants check
+	constantFee := sdk.TokensFromConsensusPower(consensus.ConstantFee, sdk.DefaultPowerReduction) // 1,000,000 HP
+	crisisGenState.ConstantFee = sdk.NewCoin(consensus.DefaultHippoDenom, constantFee)            // Spend 1,000,000 HP for invariants check
 	appState[crisistypes.ModuleName] = cdc.MustMarshalJSON(&crisisGenState)
 
 	var slashingGenState slashingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[slashingtypes.ModuleName], &slashingGenState); err != nil {
 		return nil, err
 	}
-	slashingGenState.Params.SignedBlocksWindow = 10000
-	slashingGenState.Params.MinSignedPerWindow = sdk.NewDecWithPrec(5, 2)
-	slashingGenState.Params.SlashFractionDoubleSign = sdk.NewDecWithPrec(5, 2) // 5%
-	slashingGenState.Params.SlashFractionDowntime = sdk.NewDecWithPrec(1, 4)   // 0.01%
+	slashingGenState.Params.SignedBlocksWindow = consensus.SignedBlocksWindow
+	slashingGenState.Params.MinSignedPerWindow = sdk.NewDecWithPrec(consensus.MinSignedPerWindow, 2)
+	slashingGenState.Params.SlashFractionDoubleSign = sdk.NewDecWithPrec(consensus.SlashFractionDoubleSign, 2) // 5%
+	slashingGenState.Params.SlashFractionDowntime = sdk.NewDecWithPrec(consensus.SlashFractionDowntime*100, 4) // 0.01%
 	appState[slashingtypes.ModuleName] = cdc.MustMarshalJSON(&slashingGenState)
 
 	// Override Tendermint consensus params: https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#fields

--- a/hippod/cmd/root.go
+++ b/hippod/cmd/root.go
@@ -98,7 +98,7 @@ func initAppConfig() (string, interface{}) {
 	}
 
 	srvCfg := serverconfig.DefaultConfig()
-	srvCfg.MinGasPrices = "5uhippo"
+	srvCfg.MinGasPrices = consensus.MinGasPrices
 
 	HippoAppConfig := CustomAppConfig{Config: *srvCfg}
 

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -1,0 +1,29 @@
+package consensus
+
+import "time"
+
+const (
+	MinGasPrices    = "5uhippo"
+	BlockTimeSec    = 6
+	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second
+	// staking
+	MaxValidators     = 50
+	MinCommissionRate = 5
+	// mint
+	Minter              = 25
+	InflationRateChange = 20
+	InflationMin        = 0
+	InflationMax        = 25
+	BlocksPerYear       = uint64(60*60*24*365) / uint64(BlockTimeSec)
+	// gov
+	MinDepositTokens = 100_000
+	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
+	VotingPeriod     = 60 * 60 * 24 * 3 * time.Second
+	// crisis
+	ConstantFee = 1_000_000
+	// slashing
+	SignedBlocksWindow      = 10_000
+	MinSignedPerWindow      = 5
+	SlashFractionDoubleSign = 5
+	SlashFractionDowntime   = 0.01
+)


### PR DESCRIPTION
In `hippod` directory, a lot of consensus critical policy exists as primitive value. Move those values as constant in policy.go to make it stable and manage more easily.