### PR TITLE
feat: change inflation rage to max range

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -11,7 +11,7 @@ const (
 	MinCommissionRate = 5
 	// mint
 	Minter              = 25
-	InflationRateChange = 20
+	InflationRateChange = 25
 	InflationMin        = 0
 	InflationMax        = 25
 	BlocksPerYear       = uint64(60*60*24*365) / uint64(BlockTimeSec)


### PR DESCRIPTION
As `inflation_rate_change` is max yearly change in inflation, and cosmos set its value to max diff between inflation and inflation_max/min, we also set it to max range(`inflation(25)` - `inflation_min(0)` = 25). 

ref: https://hub.cosmos.network/main/resources/genesis#mint