### PR TITLE
fix: default power reduction and denom should be in main

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"os"
 	"path/filepath"
 
@@ -185,17 +184,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 // overrideGenesis overrides some parameters in the genesis doc to the hippo-specific values.
 func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage) (json.RawMessage, error) {
-	// apply custom power reduction for 'a' base denom unit 10^18
-	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensus.DefaultHippoPrecision), nil))
-
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {
 		return nil, err
-	}
-
-	err := sdk.RegisterDenom(consensus.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensus.DefaultHippoPrecision))
-	if err != nil {
-		panic(err)
 	}
 
 	stakingGenState.Params.UnbondingTime = unbondingPeriod

--- a/hippod/main.go
+++ b/hippod/main.go
@@ -1,16 +1,27 @@
 package main
 
 import (
+	"math/big"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/server"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/hippocrat-dao/hippo-protocol/app"
 	"github.com/hippocrat-dao/hippo-protocol/hippod/cmd"
+	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
 )
 
 func main() {
+	// apply custom power reduction for 'a' base denom unit 10^18
+	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensus.DefaultHippoPrecision), nil))
+
+	err := sdk.RegisterDenom(consensus.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensus.DefaultHippoPrecision))
+	if err != nil {
+		panic(err)
+	}
+
 	rootCmd, _ := cmd.NewRootCmd()
 	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {
 		switch e := err.(type) {


### PR DESCRIPTION
Setting DefaultPowerReduction to `1 hippo`(=`10^18 ahippo`) and registering denom should be set when initialize app. I'm not fully understanding now but when it was `overrideGenesis`, it didn't work, and works as I set those before start the app.
We need to figure out further the logic behind @0114kek .

referece
1. https://github.com/xpladev/xpla/blob/bb718ae99c26d136c42c4043d2d93d4043b32919/cmd/xplad/main.go#L19
2. https://github.com/xpladev/xpla/blob/bb718ae99c26d136c42c4043d2d93d4043b32919/app/app.go#L102