### PR TITLE
refactor: declare community tax in policy

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -211,7 +211,7 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	if err := cdc.UnmarshalJSON(appState[distrtypes.ModuleName], &distrGenState); err != nil {
 		return nil, err
 	}
-	distrGenState.Params.CommunityTax = sdk.ZeroDec()
+	distrGenState.Params.CommunityTax = sdk.NewDecWithPrec(consensus.CommunityTax, 2)
 	appState[distrtypes.ModuleName] = cdc.MustMarshalJSON(&distrGenState)
 
 	var govGenState govv1types.GenesisState

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -15,6 +15,8 @@ const (
 	InflationMin        = 0
 	InflationMax        = 25
 	BlocksPerYear       = uint64(60*60*24*365) / uint64(BlockTimeSec)
+	// distr
+	CommunityTax = 0
 	// gov
 	MinDepositTokens = 100_000
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second


### PR DESCRIPTION
Include community tax in policy.go, which is configured in genesis file.