### PR TITLE
feat: increase min commission rate to default 10%

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -8,7 +8,7 @@ const (
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second
 	// staking
 	MaxValidators     = 50
-	MinCommissionRate = 5
+	MinCommissionRate = 10
 	// mint
 	Minter              = 25
 	InflationRateChange = 25


### PR DESCRIPTION
Increase min commission rate to default 10%, to prevent non-profitable validator(which makes network not sustainable).
It's temporary, so we might configure following any new strategy.