### PR TITLE
feat: extend voting period 3 days to 14days

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -20,7 +20,7 @@ const (
 	// gov
 	MinDepositTokens = 100_000
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
-	VotingPeriod     = 60 * 60 * 24 * 3 * time.Second
+	VotingPeriod     = 60 * 60 * 24 * 14 * time.Second
 	// crisis
 	ConstantFee = 1_000_000
 	// slashing


### PR DESCRIPTION
According to [cosmos](https://hub.cosmos.network/main/governance/process#governance-parameters), its voting period is 14 days same as maximum deposit period. I think it's good for us too as 14 days are enough to discuss about proposal, while 3 days are too short to discuss and vote carefully(which might cause proposal to be rammed through). 

check out description for [gov module](https://docs.cosmos.network/v0.47/build/modules/gov#parameters).