### PR TITLE
feat: min deposit for proposal set to 50,000 hp

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -218,7 +218,7 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	if err := cdc.UnmarshalJSON(appState[govtypes.ModuleName], &govGenState); err != nil {
 		return nil, err
 	}
-	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction) // 100,000 HP
+	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction) // 50,000 HP
 	govGenState.Params.MinDeposit = sdk.Coins{sdk.NewCoin(consensus.DefaultHippoDenom, minDepositTokens)}
 	maxDepositPeriod := consensus.MaxDepositPeriod // 14 days
 	govGenState.Params.MaxDepositPeriod = &maxDepositPeriod

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -18,7 +18,7 @@ const (
 	// distr
 	CommunityTax = 0
 	// gov
-	MinDepositTokens = 100_000
+	MinDepositTokens = 50_000
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
 	VotingPeriod     = 60 * 60 * 24 * 14 * time.Second
 	// crisis


### PR DESCRIPTION
According to [the proposal of cosmos](https://www.mintscan.io/cosmos/proposals/87) w.r.t. `MinDepositTokens`, the main function of this is to prevent spam proposal and encourage meaningful one. It specified exact USD value (2,500 USD) to achieve this, so we can just set our `MinDepositTokens` fairly close to that value(50,000 hp can be approximated to 2,500 USD)