### PR TITLE
feat: initial max validator limit up to 21

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -7,7 +7,7 @@ const (
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second
 	// staking
-	MaxValidators     = 50
+	MaxValidators     = 21
 	MinCommissionRate = 10
 	// mint
 	Minter              = 25


### PR DESCRIPTION
Many [cosmos projects](https://www.mintscan.io/) have validators limit from 40~180, we are not mature enough to expand to that extent. For beta launch, it would be enough to construct network with 21 validators. [Other DPOS implementaion](https://www.ledger.com/academy/what-is-delegated-proof-of-stake-dpos) like eos and tron only have 21 and 27 validators each, which means it's even safe enough for long-battled major blockchain. 
This could be increased again upon the growth of the network.