### PR TITLE
feat: lower constant fee to handle crisis

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -230,7 +230,7 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	if err := cdc.UnmarshalJSON(appState[crisistypes.ModuleName], &crisisGenState); err != nil {
 		return nil, err
 	}
-	constantFee := sdk.TokensFromConsensusPower(consensus.ConstantFee, sdk.DefaultPowerReduction) // 1,000,000 HP
+	constantFee := sdk.TokensFromConsensusPower(consensus.ConstantFee, sdk.DefaultPowerReduction) // 100,000 HP
 	crisisGenState.ConstantFee = sdk.NewCoin(consensus.DefaultHippoDenom, constantFee)            // Spend 1,000,000 HP for invariants check
 	appState[crisistypes.ModuleName] = cdc.MustMarshalJSON(&crisisGenState)
 

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -22,7 +22,7 @@ const (
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
 	VotingPeriod     = 60 * 60 * 24 * 14 * time.Second
 	// crisis
-	ConstantFee = 1_000_000
+	ConstantFee = 100_000
 	// slashing
 	SignedBlocksWindow      = 10_000
 	MinSignedPerWindow      = 5


### PR DESCRIPTION
[Cosmos](https://github.com/cosmos/gaia/blob/6159a47e1eed631e614b93595ca23f8783707dc6/docs/docs/governance/current-parameters.js#L48) currently uses 1333 atom for this, which approximates 100,000 hippo in USD value. According to [the description](https://github.com/gavinly/CosmosParametersWiki/blob/master/Crisis.md), It's fee to halt blockchain when [invariants](https://validatus.medium.com/the-power-of-invariants-understanding-stability-in-dynamic-systems-0a9870960bc7) broken(a.k.a. crisis), which mustn't happen but might be needed for unpredictable future crisis.