### PR TITLE
feat: increase community tax from 0 to 90%

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -16,7 +16,7 @@ const (
 	InflationMax        = 25
 	BlocksPerYear       = uint64(60*60*24*365) / uint64(BlockTimeSec)
 	// distr
-	CommunityTax = 0
+	CommunityTax = 90
 	// gov
 	MinDepositTokens = 50_000
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second


### PR DESCRIPTION
This is drastic change of consensus to distribute 90% of the total block reward(+fee) to community pool, which can be spent through proposal.