### PR TITLE
feat: improve tolerability by allowing upto 7 malicious validators

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -7,7 +7,7 @@ const (
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second
 	// staking
-	MaxValidators     = 21
+	MaxValidators     = 22
 	MinCommissionRate = 10
 	// mint
 	Minter              = 25


### PR DESCRIPTION
According to [PBFT paper](https://pmg.csail.mit.edu/papers/osdi99.pdf), there must be `3f + 1` nodes when `f` is malicious. According to [hyperledger](https://github.com/hyperledger-archives/sawtooth-rfcs/blob/main/text/0019-pbft-consensus.md#motivation), if `f` is not integer(has decimal point), it should floor. It means that if we set validator of 21, we can tolerate 6 malicious nodes, while we can 7 if set validator of 22, theoretically. However, it doesn't exactly match with dpos blockchain as its right to produce and validate block(message) is weighted with staked token(above description would only work if all validator has same weight). [Tendermint](https://docs.tendermint.com/v0.34/introduction/what-is-tendermint.html) adopts dpos with pbft, so practically it's not that meaningful to increase validator set. Even so, I think it would be better to increase the number of validator set from 21 to 22, mainly just to make historical info to keep examining this underlying consensus w.r.t. validator set count.
<img width="635" alt="image" src="https://github.com/user-attachments/assets/f27ea7f0-4708-4a65-bf42-e60aba0dc125" />
