### PR TITLE
feat: min uptime 75% while not slash for downtime

### DIFF
--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -25,7 +25,7 @@ const (
 	ConstantFee = 100_000
 	// slashing
 	SignedBlocksWindow      = 10_000
-	MinSignedPerWindow      = 5
+	MinSignedPerWindow      = 75
 	SlashFractionDoubleSign = 5
-	SlashFractionDowntime   = 0.01
+	SlashFractionDowntime   = 0
 )


### PR DESCRIPTION
Following https://github.com/hippocrat-dao/hippo-protocol/issues/61, increase the minimum uptime requirement.
I'm not sure whether 50% is still too generous(maybe at least 75% would be ideal), just think it'd be better to leave a room to increase for the time when our blockchain matures.
Open to any opinion! I'm still figuring out as well.