### PR TITLE
feat: init hippo sdk

### DIFF
--- a/sdk/core/.gitignore
+++ b/sdk/core/.gitignore
@@ -1,0 +1,7 @@
+# .gitignore for rust-bitcoin repository workspace.
+
+# Lock files
+Cargo.lock
+
+# Build artifacts
+target

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/sdk/core/src/main.rs
+++ b/sdk/core/src/main.rs
@@ -1,0 +1,44 @@
+pub struct Tx {
+    /// coin name(e.g. HP).
+    pub coin: String,
+    /// mostly signer address
+    pub from: String,
+    /// address to send
+    pub to: String,
+    /// amount to send
+    pub amount: String,
+    /// fee to broadcast tx
+    pub fee: String,
+    /// data to be included in tx
+    pub data: String,
+}
+
+pub struct KeyPair {
+    pub pubkey: String,
+    pub privkey: String,
+}
+
+pub struct Did {
+    pub id: String,
+}
+
+pub trait Sdk {
+    /// chain
+    fn write(data: String, privkey: String) -> Tx;
+    fn read(tx_hash: String) -> Tx;
+    fn send(from: String, to: String, privkey: String, data: Option<String>) -> Tx;
+    /// did
+    fn create_keypair() -> KeyPair;
+    fn key_to_did(pubkey: String) -> Did;
+    fn did_to_key(did: Did) -> String;
+    /// cryptography
+    fn encrypt(data: String, pubkey: String) -> String;
+    fn decrypt(data: String, privkey: String) -> String;
+    fn sign(data: String, privkey: String) -> String;
+    fn verify(data: String, sig: String, pubkey: String) -> String;
+    fn sha256(data: String) -> String;
+}
+
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Add hippo-sdk directory as monorepo(inside the hippo-protocol), supporting some essential protocol-related methods independent from the blockchain core node, for faster and safer implementation.
Plan to support the interface for various languages, on the basis of compiled binary of rust.
It's basically library but with more intensive features and symbolic semantics.
