### PR TITLE
docs: hippo-protocol docs v0.1

### DIFF
--- a/docs/docs/delegators/delegator-faq.md
+++ b/docs/docs/delegators/delegator-faq.md
@@ -17,7 +17,7 @@ For a practical guide on how to become a delegator, click [here](./delegator-gui
 
 <!-- markdown-link-check-disable-next-line -->
 
-In order to choose their validators, delegators have access to a range of information directly in [Hippo River](https://mintscan.io/cosmos/validators) or other Hippo Protocol block explorers.
+In order to choose their validators, delegators have access to a range of information directly in [Hippo River](https://river.hippoprotocol.ai/hippo-protocol/staking) or other Hippo Protocol block explorers.
 
 - **Validator's moniker**: Name of the validator candidate.
 - **Validator's description**: Description provided by the validator operator.
@@ -40,7 +40,7 @@ Being a delegator is not a passive task. Here are the main directives of a deleg
 Validators and delegators earn revenue in exchange for their services. This revenue is given in three forms:
 
 - **Block provisions (HPs):** They are paid in newly created HPs. Block provisions exist to incentivize HP holders to stake. The yearly inflation rate begins with 25% and decreases to 0 as time goes, pursuing sustainable incentive economy only with fees, similar to that of Bitcoin.
-- **Transaction fees (various tokens):** Each transfer on the Hippo Protocol comes with transactions fees. These fees can be paid in any currency that is whitelisted by the Hub's governance. Fees are distributed to bonded HP holders in proportion to their stake. The first whitelisted token at launch is the HP.
+- **Transaction fees (HPs):** Each transfer on the Hippo Protocol comes with transactions fees. These fees can be paid in HPs. Fees are distributed to bonded HP holders in proportion to their stake. The first whitelisted token at launch is the HP.
 
 ## Validator Commission
 
@@ -51,9 +51,9 @@ We consider a validator whose stake (i.e. self-delegated stake + delegated stake
 - 990 HPs in block provisions
 - 10 HPs in transaction fees.
 
-This amounts to a total of 1000 HPs and 100 Photons to be distributed among all staking pools.
+This amounts to a total of 1000 HPs to be distributed among all staking pools.
 
-Our validator's staking pool represents 10% of the total stake, which means the pool obtains 100 HPs and 10 Photons. Now let us look at the internal distribution of revenue:
+Our validator's staking pool represents 10% of the total stake, which means the pool obtains 100 HPs. Now let us look at the internal distribution of revenue:
 
 - Commission = `10% * 80% * 100` HPs = 8 HPs
 - Validator's revenue = `20% * 100` HPs + Commission = 28 HPs

--- a/docs/docs/getting-started/README.md
+++ b/docs/docs/getting-started/README.md
@@ -1,0 +1,9 @@
+---
+title: Getting Started
+order: 1
+---
+
+This folder contains tutorials related to the `hippo` application.
+
+- [What is Hippo?](./what-is-hippo.md)
+- [Installing `hippod`](./installation.md)

--- a/docs/docs/getting-started/_category_.json
+++ b/docs/docs/getting-started/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Getting Started",
+    "position": 2,
+    "link": { "type": "doc", "id": "getting-started/README" }
+}

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -1,0 +1,53 @@
+---
+title: Installing Hippo
+sidebar_position: 2
+---
+
+This guide will explain how to install the `hippod` binary and run the cli. With this binary installed on a server, you can participate on the mainnet as either a [Full Node](../hub-tutorials/join-mainnet.md) or a [Validator](../validators/validator-setup.md).
+
+## Running testnets with `hippod`
+
+If you want to spin up a quick testnet with your friends, you can follow these steps.
+Unless otherwise noted, every step must be done by everyone who wants to participate
+in this testnet.
+
+1. If you've run `hippod` before, you may need to reset your genesis file(including gentx) and database before starting a new
+   testnet. You can do with the following command: `$ rm -rf .hippo` from your
+   Home(or User) directory. If you want to reset only database, just do `$ go run hippod/main.go tendermint unsafe-reset-all` in root dir.
+2. `$ go run hippod/main.go init hippo --chain-id hippo-protocol-testnet-1`. This will initialize a new working directory
+   at the default location `~/.hippod`. You need to provide a "moniker" and a "chain id". These
+   two names are "hippo" and "hippo-protocol-testnet-1" here. If you want to overwrite just genesis file(not including gentx), add `--overwrite` flag.
+3. `$ go run hippod/main.go keys add alice`. This will create a new key, with a name of your choosing(for here, alice).
+   Save the output of this command somewhere; you'll need the address generated here later.
+4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
+   before; and `1084734273380000000000000000ahp` is `amount`.
+5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1`. This will create the genesis
+   transaction for your new chain. Here `amount` should be at least `1000000000000000000ahp`. If you
+   provide too much or too little, you will encounter an error when starting your node.
+6. Now, one person needs to create the genesis file `genesis.json` using the genesis transactions
+   from every participant, by gathering all the genesis transactions under `config/gentx` and then
+   calling `$ go run hippod/main.go genesis collect-gentxs`. This will create a new `genesis.json` file that includes data
+   from all the validators (we sometimes call it the "super genesis file" to distinguish it from
+   single-validator genesis files).
+7. Once you've received the super genesis file, overwrite your original `genesis.json` file with
+   the new super `genesis.json`.
+8. Modify your `config/config.toml` (in the `.hippo` working directory) to include the other participants as
+   persistent peers:
+
+   ```text
+   # Comma separated list of nodes to keep persistent connections to
+   persistent_peers = "[validator_address]@[ip_address]:[port],[validator_address]@[ip_address]:[port]"
+   ```
+
+   You can find `validator_address` by running `$ go run hippod/main.go tendermint show-node-id`. The output will
+   be the hex-encoded `validator_address`. The default `port` is 26656.
+
+9. Now you can start your nodes: `$ go run hippod/main.go start`.
+
+10. You can also now build binary `$ make build`, and then `$ cd build`, where you can use command line starting with `$ hippod`.
+
+Now you have a hippod testnet that you can use to try out changes to the Cosmos SDK or Tendermint!
+
+NOTE: Sometimes creating the network through the `collect-gentxs` will fail, and validators will start
+in a funny state (and then panic). If this happens, you can try to create and start the network first
+with a single validator and then add additional validators using a `create-validator` transaction.

--- a/docs/docs/getting-started/what-is-hippo.md
+++ b/docs/docs/getting-started/what-is-hippo.md
@@ -1,0 +1,18 @@
+---
+title: What is Hippo Protocol?
+sidebar_position: 1
+---
+
+The Hippo Protocol is a public Proof-of-Stake chain that uses HP as its native staking token. It is a cooperative protocol for healthcare data collection & utilization, and developed using the [cosmos-sdk](https://docs.cosmos.network/) development framework and [ibc-go](https://ibc.cosmos.network/).
+
+:::info
+
+- `hippo` is the name of the Cosmos SDK application for the Hippo Protocol.
+
+- `hippod` is the daemon and command-line interface (CLI) that operates the `hippo` blockchain application.
+
+:::
+
+For a full list of modules used on the Hippo Protocol follow this [link](../modules/README.md).
+
+Next, learn how to [install Hippo](./installation.md).

--- a/docs/docs/governance/current-parameters.js
+++ b/docs/docs/governance/current-parameters.js
@@ -21,7 +21,7 @@ export const currentParams = {
     governanceProposalLink: "",
   },
   proposals: {
-    numberOfValidatorsProp: "https://www.mintscan.io/cosmos/proposals/797",
+    numberOfValidatorsProp: "https://river.hippoprotocol.ai/hippo-protocol/staking",
   },
   auth: {
     max_memo_characters: "512",

--- a/docs/docs/governance/proposal-types/community-pool-spend.md
+++ b/docs/docs/governance/proposal-types/community-pool-spend.md
@@ -26,7 +26,7 @@ You may directly query the Hippo Protocol for the balance of the Community Pool:
 
 `hippod q distribution community-pool --chain-id hippo-protocol-1 --node <rpc-node-address> `
 
-Alternatively, popular Hippo explorers such as [Hippo River](https://www.mintscan.io/cosmos) display the ongoing Community Pool balance.
+Alternatively, popular Hippo explorers such as [Hippo River](https://river.hippoprotocol.ai/) display the ongoing Community Pool balance.
 
 ### How can funds from the Community Pool be spent?
 

--- a/docs/docs/governance/submitting.md
+++ b/docs/docs/governance/submitting.md
@@ -214,7 +214,7 @@ Use `hippod tx gov --help` to get more info about the CLI options, we will expla
 
 ### Verifying your transaction
 
-After posting your transaction, your command line interface (hippod) will provide you with the transaction's hash, which you can either query using hippod or by searching the transaction hash using [Hippo River](https://www.mintscan.io/cosmos/txs/0506447AE8C7495DE970736474451CF23536DF8EA837FAF1CF6286565589AB57). The hash should look something like this: `0506447AE8C7495DE970736474451CF23536DF8EA837FAF1CF6286565589AB57`.
+After posting your transaction, your command line interface (hippod) will provide you with the transaction's hash, which you can either query using hippod or by searching the transaction hash using [Hippo River](hhttps://river.hippoprotocol.ai/hippo-protocol/tx). The hash should look something like this: `0506447AE8C7495DE970736474451CF23536DF8EA837FAF1CF6286565589AB57`.
 
 Alternatively, you can check your Tx status and information using:
 

--- a/docs/docs/hub-tutorials/join-mainnet.md
+++ b/docs/docs/hub-tutorials/join-mainnet.md
@@ -46,7 +46,7 @@ For instructions to join as a validator, please also see the [Validator Guide](.
 
 There are many explorers for the Hippo Protocol. For reference while setting up a node, here are a few recommendations:
 
-- [Hippo River](https://www.mintscan.io)
+- [Hippo River](https://river.hippoprotocol.ai/)
 
 * [Ping.Pub](https://ping.pub/hippo-protocol)
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,7 +31,7 @@ These community-maintained web and mobile wallets allow you to store & transfer 
 
 These block explorers allow you to search, view and analyze Hippo Protocol data&mdash;like blocks, transactions, validators, etc.
 
-- [Hippo River](https://mintscan.io)
+- [Hippo River](https://river.hippoprotocol.ai/)
 - [Ping.Pub](https://ping.pub/hippo-protocol)
 
 ## Hippo Protocol CLI

--- a/docs/docs/resources/genesis.md
+++ b/docs/docs/resources/genesis.md
@@ -120,8 +120,10 @@ The `bank` module handles tokens. The only parameter that needs to be defined in
 
 ```json
 "bank": {
-      "send_enabled": false
-    }
+      "params": {
+        "send_enabled": [],
+        "default_send_enabled": true
+      }
 ```
 
 ### Staking

--- a/docs/docs/resources/service-providers.md
+++ b/docs/docs/resources/service-providers.md
@@ -65,43 +65,39 @@ All available CLI commands are shown when you run the `hippod` command:
 hippod
 ```
 
-```bash
-Stargate Hippo Protocol App
+````bash
+Hippo App
 
 Usage:
-  hippod [command]
+hippod [command]
 
 Available Commands:
-
-
-  add-genesis-account Add a genesis account to genesis.json
-  collect-gentxs      Collect genesis txs and output a genesis.json file
-  debug               Tool for helping with debugging your application
-  export              Export state to JSON
-  gentx               Generate a genesis tx carrying a self delegation
-  help                Help about any command
-  init                Initialize private validator, p2p, genesis, and application configuration files
-  keys                Manage your application's keys
-  migrate             Migrate genesis to a specified target version
-  query               Querying subcommands
-  start               Run the full node
-  status              Query remote node for status
-  tendermint          Tendermint subcommands
-  testnet             Initialize files for a simapp testnet
-  tx                  Transactions subcommands
-  unsafe-reset-all    Resets the blockchain database, removes address book files, and resets data/priv_validator_state.json to the genesis state
-  validate-genesis    validates the genesis file at the default location or at the location passed as an arg
-  version             Print the application binary version information
+config Create or query an application CLI configuration file
+debug Tool for helping with debugging your application
+export Export state to JSON
+genesis Application's genesis-related subcommands
+help Help about any command
+init Initialize private validator, p2p, genesis, and application configuration files
+keys Manage your application's keys
+prune Prune app history states by keeping the recent heights and deleting old heights
+query Querying subcommands
+rollback rollback cosmos-sdk and tendermint state by one height
+snapshots Manage local snapshots
+start Run the full node
+status Query remote node for status
+tendermint Tendermint subcommands
+tx Transactions subcommands
+version Print the application binary version information
 
 Flags:
-  -h, --help                help for hippod
-      --home string         directory for config and data (default "/Users/tobias/.hippo")
-      --log_format string   The logging format (json|plain) (default "plain")
-      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
-      --trace               print out full stack trace on errors
+-h, --help help for hippod
+--home string directory for config and data (default "/home/kek0114/.hippo")
+--log_format string The logging format (json|plain) (default "plain")
+--log_level string The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
+--log_no_color Disable colored logs
+--trace print out full stack trace on errors
 
-Use "hippod [command] --help" for more information about a command.
-```
+Use "hippod [command] --help" for more information about a command.```
 
 For each displayed command, you can use the `--help` flag to get further information.
 
@@ -144,7 +140,7 @@ Global Flags:
       --trace               print out full stack trace on errors
 
 Use "hippod query [command] --help" for more information about a command.
-```
+````
 
 ### Remote Access to hippod
 

--- a/docs/docs/validators/overview.md
+++ b/docs/docs/validators/overview.md
@@ -9,7 +9,7 @@ The Hippo Protocol is based on [CometBFT](https://docs.cometbft.com/v0.37/introd
 
 Validator candidates can bond their own HP and have HP ["delegated"](../delegators/delegator-guide-cli.md), or staked, to them by token holders. The Hippo Protocol can have 22 active validators, but over time the number of validators can be changed through governance (`MaxValidators` parameter). Validator voting power is determined by the total number of HP tokens delegated to them. Validators that do not have enough voting power to be in the top 22 are considered inactive. Inactive validators can become active if their staked amount increases so that they fall into the top 22 validators.
 
-Validators and their delegators earn HP as block provisions and tokens as transaction fees through execution of the Tendermint consensus protocol. Note that validators can set a commission percentage on the fees their delegators receive as additional incentive. You can find an overview of all current validators and their voting power on [Hippo River](https://www.mintscan.io/cosmos/validators).
+Validators and their delegators earn HP as block provisions and tokens as transaction fees through execution of the Tendermint consensus protocol. Note that validators can set a commission percentage on the fees their delegators receive as additional incentive. You can find an overview of all current validators and their voting power on [Hippo River](https://river.hippoprotocol.ai/hippo-protocol/staking).
 
 If validators double sign or are offline for an [extended period](./validator-faq.md#what-are-the-slashing-conditions), their staked HP (including HP of users that delegated to them) can be slashed. The penalty depends on the severity of the violation.
 

--- a/docs/docs/validators/validator-faq.md
+++ b/docs/docs/validators/validator-faq.md
@@ -22,7 +22,7 @@ The Hippo Protocol is a public Proof-Of-Stake (PoS) blockchain, meaning that the
 
 Any user in the system can declare their intention to become a validator by sending a `create-validator` transaction to become validator candidates.
 
-The weight (i.e. voting power) of a validator determines whether they are an active validator. The active validator set is limited to [an amount](https://www.mintscan.io/cosmos/validators) that changes over time.
+The weight (i.e. voting power) of a validator determines whether they are an active validator. The active validator set is limited to [an amount](https://river.hippoprotocol.ai/hippo-protocol/staking) that changes over time.
 
 ### What is a full node?
 
@@ -96,7 +96,7 @@ Validator bond is a delegation of HP from a delegator to a validator. Validator 
 
 ### Is there a minimum amount of HP that must be delegated to be an active (bonded) validator?
 
-The minimum is 1 HP. But the network is currently secured by much higher values. You can check the minimum required HP to become part of the active validator set on the [Hippo River validator page](https://www.mintscan.io/hippo/validators).
+The minimum is 1 HP. But the network is currently secured by much higher values. You can check the minimum required HP to become part of the active validator set on the [Hippo River validator page](https://river.hippoprotocol.ai/hippo-protocol/staking).
 
 ### How do delegators choose their validators?
 

--- a/docs/docs/validators/validator-setup.md
+++ b/docs/docs/validators/validator-setup.md
@@ -52,7 +52,7 @@ hippod tx staking create-validator \
 When specifying commission parameters, the `commission-max-change-rate` is used to measure % _point_ change over the `commission-rate`. E.g. 1% to 2% is a 100% rate increase, but only 1 percentage point.
 :::
 
-It's possible that you won't have enough HP to be part of the active set of validators in the beginning. Users are able to delegate to inactive validators (those outside of the active set) using the [Keplr web app](https://wallet.keplr.app/#/hippo-protocol/stake?tab=inactive-validators). You can confirm that you are in the validator set by using a third party explorer like [Hippo River](https://www.mintscan.io/cosmos/validators).
+It's possible that you won't have enough HP to be part of the active set of validators in the beginning. Users are able to delegate to inactive validators (those outside of the active set) using the [Keplr web app](https://wallet.keplr.app/#/hippo-protocol/stake?tab=inactive-validators). You can confirm that you are in the validator set by using a third party explorer like [Hippo River](https://river.hippoprotocol.ai/hippo-protocol/staking).
 
 ## Edit Validator Description
 


### PR DESCRIPTION
Following the discussion in https://github.com/hippocrat-dao/hippo-protocol/issues/70,
- revive `getting-started` docs, which also includes guideline to use `hippod` command.
- fix some wrong contents
- add hippo river url for any explorer related link.