### PR TITLE
fix: limit for max block and gas, remove crisis module, fix account keeper bech32 prefix, extend evidence param

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -65,9 +65,6 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		allowedAddrsMap[addr] = true
 	}
 
-	/* Just to be safe, assert the invariants on current state. */
-	app.CrisisKeeper.AssertInvariants(ctx)
-
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -16,8 +16,6 @@ import (
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
@@ -64,7 +62,6 @@ type AppKeepersWithKey struct {
 	MintKeeper            mintkeeper.Keeper
 	DistrKeeper           distrkeeper.Keeper
 	GovKeeper             govkeeper.Keeper
-	CrisisKeeper          *crisiskeeper.Keeper
 	UpgradeKeeper         *upgradekeeper.Keeper
 	ParamsKeeper          paramskeeper.Keeper
 	AuthzKeeper           authzkeeper.Keeper
@@ -129,10 +126,6 @@ func (appKeepers *AppKeepersWithKey) InitKeyAndKeepers(
 	appKeepers.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec, legacyAmino, appKeepers.keys[slashingtypes.StoreKey], appKeepers.StakingKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
-
-	invCheckPeriod := cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod))
-	appKeepers.CrisisKeeper = crisiskeeper.NewKeeper(appCodec, appKeepers.keys[crisistypes.StoreKey], invCheckPeriod,
-		appKeepers.BankKeeper, authtypes.FeeCollectorName, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	appKeepers.FeeGrantKeeper = feegrantkeeper.NewKeeper(appCodec, appKeepers.keys[feegrant.StoreKey], appKeepers.AccountKeeper)
 
@@ -215,7 +208,6 @@ func initParamsKeeper(appCodec codec.Codec, legacyAmino *codec.LegacyAmino, key,
 	paramsKeeper.Subspace(distrtypes.ModuleName)
 	paramsKeeper.Subspace(slashingtypes.ModuleName)
 	paramsKeeper.Subspace(govtypes.ModuleName)
-	paramsKeeper.Subspace(crisistypes.ModuleName)
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
 	paramsKeeper.Subspace(ibcexported.ModuleName)
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
@@ -52,6 +51,7 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	appparams "github.com/hippocrat-dao/hippo-protocol/app/params"
+	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
 	"github.com/spf13/cast"
 )
 
@@ -109,7 +109,7 @@ func (appKeepers *AppKeepersWithKey) InitKeyAndKeepers(
 	appKeepers.ScopedTransferKeeper = appKeepers.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
 
 	// add keepers
-	appKeepers.AccountKeeper = authkeeper.NewAccountKeeper(appCodec, appKeepers.keys[authtypes.StoreKey], authtypes.ProtoBaseAccount, maccPerms, sdk.Bech32MainPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
+	appKeepers.AccountKeeper = authkeeper.NewAccountKeeper(appCodec, appKeepers.keys[authtypes.StoreKey], authtypes.ProtoBaseAccount, maccPerms, consensus.AddrPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	appKeepers.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec,

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -8,7 +8,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
@@ -25,7 +24,7 @@ import (
 
 func (appKeepers *AppKeepersWithKey) GenerateKeys() {
 	appKeepers.keys = sdk.NewKVStoreKeys(
-		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey, crisistypes.StoreKey,
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
 		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
 		govtypes.StoreKey, paramstypes.StoreKey, consensusparamtypes.StoreKey, upgradetypes.StoreKey, feegrant.StoreKey,
 		evidencetypes.StoreKey, capabilitytypes.StoreKey,

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cosmos/go-bip39"
 	"github.com/pkg/errors"
 
-	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -228,14 +227,6 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	votingPeriod := consensus.VotingPeriod
 	govGenState.Params.VotingPeriod = &votingPeriod
 	appState[govtypes.ModuleName] = cdc.MustMarshalJSON(&govGenState)
-
-	var crisisGenState crisistypes.GenesisState
-	if err := cdc.UnmarshalJSON(appState[crisistypes.ModuleName], &crisisGenState); err != nil {
-		return nil, err
-	}
-	constantFee := sdk.TokensFromConsensusPower(consensus.ConstantFee, sdk.DefaultPowerReduction) // 100,000 HP
-	crisisGenState.ConstantFee = sdk.NewCoin(consensus.DefaultHippoDenom, constantFee)            // Spend 1,000,000 HP for invariants check
-	appState[crisistypes.ModuleName] = cdc.MustMarshalJSON(&crisisGenState)
 
 	var slashingGenState slashingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[slashingtypes.ModuleName], &slashingGenState); err != nil {

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -184,6 +184,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 // overrideGenesis overrides some parameters in the genesis doc to the hippo-specific values.
 func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage) (json.RawMessage, error) {
+	genDoc.ConsensusParams.Block.MaxBytes = consensus.MaxBlockSize // 4MB
+
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {
 		return nil, err

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -185,6 +185,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 // overrideGenesis overrides some parameters in the genesis doc to the hippo-specific values.
 func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage) (json.RawMessage, error) {
 	genDoc.ConsensusParams.Block.MaxBytes = consensus.MaxBlockSize // 4MB
+	genDoc.ConsensusParams.Block.MaxGas = consensus.MaxBlockGas    // 100 milion
 
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -28,4 +28,7 @@ const (
 	MinSignedPerWindow      = 75
 	SlashFractionDoubleSign = 5
 	SlashFractionDowntime   = 0
+	// evidence
+	MaxAgeDuration  = UnbondingPeriod * 30 / 21 // 30 days
+	MaxAgeNumBlocks = BlocksPerYear * 30 / 365  // 30 days
 )

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -3,6 +3,7 @@ package consensus
 import "time"
 
 const (
+	MaxBlockSize    = 4194304 // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
 	MinGasPrices    = "5000000000000" + DefaultHippoDenom
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -3,7 +3,8 @@ package consensus
 import "time"
 
 const (
-	MaxBlockSize    = 4194304 // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
+	MaxBlockSize    = 4194304   // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
+	MaxBlockGas     = 100000000 // 100 milion, a single MsgSend Tx consumes 50,000~100,000 gas.
 	MinGasPrices    = "5000000000000" + DefaultHippoDenom
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -23,8 +23,6 @@ const (
 	MinDepositTokens = 50_000
 	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
 	VotingPeriod     = 60 * 60 * 24 * 14 * time.Second
-	// crisis
-	ConstantFee = 100_000
 	// slashing
 	SignedBlocksWindow      = 10_000
 	MinSignedPerWindow      = 75


### PR DESCRIPTION
- [af16263c4d96acb6c3176394821fb8df91de8d89](https://github.com/hippocrat-dao/hippo-protocol/commit/af16263c4d96acb6c3176394821fb8df91de8d89): max block size limit decrease to 4mb to prevent DoS
related issue: https://github.com/hippocrat-dao/hippo-protocol/issues/75
- [9e8987f9b5540279710ba79fdd46a6bc9e9a2a17](https://github.com/hippocrat-dao/hippo-protocol/commit/9e8987f9b5540279710ba79fdd46a6bc9e9a2a17): max block gas limit decrease to 100 mil to prevent DoS
related issue: https://github.com/hippocrat-dao/hippo-protocol/issues/73
- [1d85b651e37f77e901be9ded8e99b49db91c37ec](https://github.com/hippocrat-dao/hippo-protocol/pull/76/commits/1d85b651e37f77e901be9ded8e99b49db91c37ec): bech32 prefix must be hippo instead of cosmos.
related issue: https://github.com/hippocrat-dao/hippo-protocol/issues/81
- [21a732d83db3182b348ba77d1a13888080af19f5](https://github.com/hippocrat-dao/hippo-protocol/pull/76/commits/21a732d83db3182b348ba77d1a13888080af19f5): remove crisis dependency
related issue: https://github.com/hippocrat-dao/hippo-protocol/issues/82
- [6ca2a7dab8b97901dd642a6c42edba5f6f606e72](https://github.com/hippocrat-dao/hippo-protocol/pull/76/commits/6ca2a7dab8b97901dd642a6c42edba5f6f606e72): extend max evidence age param longer than bonding period
related issue: https://github.com/hippocrat-dao/hippo-protocol/issues/74