### PR TITLE
Fix/audit10

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -90,6 +91,8 @@ import (
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
+
+	consensustypes "github.com/hippocrat-dao/hippo-protocol/types/consensus"
 )
 
 const Name = "hippo"
@@ -182,6 +185,14 @@ func init() {
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+Name)
+
+	// apply custom power reduction for 'a' base denom unit 10^18
+	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensustypes.DefaultHippoPrecision), nil))
+
+	err = sdk.RegisterDenom(consensustypes.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensustypes.DefaultHippoPrecision))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // New returns a reference to an initialized Gaia.

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -184,6 +184,8 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 // overrideGenesis overrides some parameters in the genesis doc to the hippo-specific values.
 func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage) (json.RawMessage, error) {
+	genDoc.ConsensusParams.Block.MaxBytes = consensus.MaxBlockSize // 4MB
+
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {
 		return nil, err

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -185,6 +185,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 // overrideGenesis overrides some parameters in the genesis doc to the hippo-specific values.
 func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage) (json.RawMessage, error) {
 	genDoc.ConsensusParams.Block.MaxBytes = consensus.MaxBlockSize // 4MB
+	genDoc.ConsensusParams.Block.MaxGas = consensus.MaxBlockGas    // 100 milion
 
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {

--- a/hippod/main.go
+++ b/hippod/main.go
@@ -1,26 +1,16 @@
 package main
 
 import (
-	"math/big"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/server"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/hippocrat-dao/hippo-protocol/app"
 	"github.com/hippocrat-dao/hippo-protocol/hippod/cmd"
-	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
 )
 
 func main() {
-	// apply custom power reduction for 'a' base denom unit 10^18
-	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensus.DefaultHippoPrecision), nil))
-
-	err := sdk.RegisterDenom(consensus.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensus.DefaultHippoPrecision))
-	if err != nil {
-		panic(err)
-	}
 
 	rootCmd, _ := cmd.NewRootCmd()
 	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -3,6 +3,7 @@ package consensus
 import "time"
 
 const (
+	MaxBlockSize    = 4194304 // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
 	MinGasPrices    = "5000000000000" + DefaultHippoDenom
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -3,7 +3,8 @@ package consensus
 import "time"
 
 const (
-	MaxBlockSize    = 4194304 // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
+	MaxBlockSize    = 4194304   // 4MB, a single MsgSend Tx counts 200~500 bytes normally.
+	MaxBlockGas     = 100000000 // 100 milion, a single MsgSend Tx consumes 50,000~100,000 gas.
 	MinGasPrices    = "5000000000000" + DefaultHippoDenom
 	BlockTimeSec    = 6
 	UnbondingPeriod = 60 * 60 * 24 * 7 * 3 * time.Second


### PR DESCRIPTION
This pull request includes various changes to the `app` and `hippod` directories, focusing on importing necessary packages, setting custom parameters, and improving the export functionality. The most important changes include importing new packages, setting custom power reduction and block parameters, and enhancing the genesis state export process.

### Importing necessary packages:
* [`app/app.go`](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R7): Added import for `math/big` and `consensustypes` to support new functionalities. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R7) [[2]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R94-R95)

### Setting custom parameters:
* [`app/app.go`](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R188-R195): Applied custom power reduction for the base denom unit and registered the custom denom.
* [`hippod/cmd/init.go`](diffhunk://#diff-84474618903668764c30d2e3554477e7a4a56c5383e630ed6fee41003563b179R187-R189): Overridden genesis parameters to set maximum block size and gas.

### Enhancing export functionality:
* [`app/export.go`](diffhunk://#diff-9bcaf321191d4f6106e27485bdfbbaef716b4e0e4f648d8e5b81a87bc93b6c77L31-R55): Modified the `ExportAppStateAndValidators` function to filter and export specific modules' genesis state if requested.

### Removing redundant code:
* [`hippod/main.go`](diffhunk://#diff-d193486be3c480c63f7dad335a22c28adf71605e4047539469d3d6d00ab7b030L4-L23): Removed redundant code related to custom power reduction and denom registration, which is now handled in `app/app.go`.

### Defining consensus parameters:
* [`types/consensus/policy.go`](diffhunk://#diff-61bcba74ea9c73d263e8f76d7523deb948d7d0513605248df6ee762777f53fe7R6-R7): Added constants for maximum block size and gas.