### PR TITLE
Fix/misplaced config cli filters genesis export

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -90,6 +91,8 @@ import (
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
+
+	consensustypes "github.com/hippocrat-dao/hippo-protocol/types/consensus"
 )
 
 const Name = "hippo"
@@ -182,6 +185,14 @@ func init() {
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+Name)
+
+	// apply custom power reduction for 'a' base denom unit 10^18
+	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensustypes.DefaultHippoPrecision), nil))
+
+	err = sdk.RegisterDenom(consensustypes.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensustypes.DefaultHippoPrecision))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // New returns a reference to an initialized Gaia.

--- a/hippod/main.go
+++ b/hippod/main.go
@@ -1,26 +1,16 @@
 package main
 
 import (
-	"math/big"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/server"
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/hippocrat-dao/hippo-protocol/app"
 	"github.com/hippocrat-dao/hippo-protocol/hippod/cmd"
-	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
 )
 
 func main() {
-	// apply custom power reduction for 'a' base denom unit 10^18
-	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(consensus.DefaultHippoPrecision), nil))
-
-	err := sdk.RegisterDenom(consensus.DefaultHippoDenom, sdk.NewDecWithPrec(1, consensus.DefaultHippoPrecision))
-	if err != nil {
-		panic(err)
-	}
 
 	rootCmd, _ := cmd.NewRootCmd()
 	if err := svrcmd.Execute(rootCmd, "", app.DefaultNodeHome); err != nil {


### PR DESCRIPTION
This pull request includes several changes to the `app/app.go` and `app/export.go` files to enhance functionality and improve code organization. The most important changes include adding new imports, initializing custom power reduction, and modifying the export of app state and validators.

### Enhancements and New Features:

* [`app/app.go`](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R7): Added new imports for `math/big` and `consensustypes` to support custom power reduction and denom registration. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R7) [[2]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R94-R95)
* [`app/app.go`](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R188-R195): Initialized custom power reduction for the 'a' base denom unit and registered the denom with specific precision.

### Code Organization and Cleanup:

* [`app/export.go`](diffhunk://#diff-9bcaf321191d4f6106e27485bdfbbaef716b4e0e4f648d8e5b81a87bc93b6c77L31-R55): Modified the `ExportAppStateAndValidators` function to export all module states and filter them based on `modulesToExport` if specified.
* [`hippod/main.go`](diffhunk://#diff-d193486be3c480c63f7dad335a22c28adf71605e4047539469d3d6d00ab7b030L4-L23): Removed redundant code related to custom power reduction and denom registration, as this is now handled in `app/app.go`.