### PR TITLE
refactor: Use of magic numbers decreases maintainability

### DIFF
--- a/app/inflation.go
+++ b/app/inflation.go
@@ -6,6 +6,14 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
+const (
+	// GenesisSupply is the initial supply of tokens at genesis.
+	GenesisSupply int64 = 1_084_734_273
+
+	// FirstYearInflatedToken is the amount of tokens to be inflated in the first year.
+	FirstYearInflatedToken int64 = 271_183_568
+)
+
 // InflationCalculationFn defines the function required to calculate inflation rate during
 // BeginBlock. It receives the minter and params stored in the keeper, along with the current
 // bondedRatio and returns the newly calculated inflation rate.
@@ -28,11 +36,8 @@ func CustomInflationCalculationFn(ctx sdk.Context, minter minttypes.Minter, para
 	//
 	//	inflation <- targetInflatedToken / (targetSupply - (targetInflatedToken * equalizer ))
 
-	genesisSupply := int64(1_084_734_273)
-	firstYearInflatedToken := int64(271_183_568)
-
-	targetSupply := genesisSupply
-	targetInflatedToken := firstYearInflatedToken
+	targetSupply := GenesisSupply
+	targetInflatedToken := FirstYearInflatedToken
 	currentYear := 1 + (ctx.BlockHeight() / int64(params.BlocksPerYear))
 
 	for i := int64(1); i <= currentYear; i++ {


### PR DESCRIPTION
Use of magic numbers decreases maintainability

- Hard-coded number literals without context or description (magic numbers) are used in app/inflation.go (lines 31-32), reducing code readability and maintainability.
- To enhance readability and maintainability, these numbers have been replaced with well-documented constants