### PR TITLE
refactor: remove duplicate makeEncodingConfig & define magic number constants

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/store/streaming"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	"github.com/cosmos/cosmos-sdk/x/auth/posthandler"
@@ -82,8 +81,6 @@ import (
 	ibcgovclient "github.com/cosmos/ibc-go/v7/modules/core/02-client/client"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
-
-	appparams "github.com/hippocrat-dao/hippo-protocol/app/params"
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
@@ -190,7 +187,7 @@ func New(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
-	encodingConfig := makeEncodingConfig()
+	encodingConfig := MakeEncodingConfig()
 
 	appCodec := encodingConfig.Codec
 	legacyAmino := encodingConfig.Amino
@@ -535,13 +532,4 @@ func (app *App) setupUpgradeHandlers() {
 			u.CreateUpgradeHandler(app.ModuleManager, app.configurator, &app.AppKeepersWithKey),
 		)
 	}
-}
-
-func makeEncodingConfig() appparams.EncodingConfig {
-	encodingConfig := appparams.MakeEncodingConfig()
-	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-	return encodingConfig
 }

--- a/app/inflation.go
+++ b/app/inflation.go
@@ -6,6 +6,14 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
+const (
+	// GenesisSupply is the initial supply of tokens at genesis.
+	GenesisSupply int64 = 1_084_734_273
+
+	// FirstYearInflatedToken is the amount of tokens to be inflated in the first year.
+	FirstYearInflatedToken int64 = 271_183_568
+)
+
 // InflationCalculationFn defines the function required to calculate inflation rate during
 // BeginBlock. It receives the minter and params stored in the keeper, along with the current
 // bondedRatio and returns the newly calculated inflation rate.
@@ -28,11 +36,8 @@ func CustomInflationCalculationFn(ctx sdk.Context, minter minttypes.Minter, para
 	//
 	//	inflation <- targetInflatedToken / (targetSupply - (targetInflatedToken * equalizer ))
 
-	genesisSupply := int64(1_084_734_273)
-	firstYearInflatedToken := int64(271_183_568)
-
-	targetSupply := genesisSupply
-	targetInflatedToken := firstYearInflatedToken
+	targetSupply := GenesisSupply
+	targetInflatedToken := FirstYearInflatedToken
 	currentYear := 1 + (ctx.BlockHeight() / int64(params.BlocksPerYear))
 
 	for i := int64(1); i <= currentYear; i++ {


### PR DESCRIPTION
**Resolve 2 Informational Severities**

1. Redundant definition of MakeEncodingConfig function

- The makeEncodingConfig function was defined in both app/app.go and app/encoding.go. This duplication increases maintenance complexity and risks inconsistencies.
- The redundant definition in app/app.go is removed, and references have been updated to use the implementation in app/encoding.go.

2. Use of magic numbers decreases maintainability

- Hard-coded number literals without context or description (magic numbers) are used in app/inflation.go, reducing code readability and maintainability.
- To enhance readability and maintainability, these numbers have been replaced with well-documented constants