### PR TITLE
chore: add dependabot.yml to exclude docs in monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    exclude-patterns:
+      - "/docs/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Our [dependabot](https://github.com/hippocrat-dao/hippo-protocol/security/dependabot) checks all the scope of repo including`docs/**`, which makes the irrelevant noise for our core code. Use dependabot.yml to exclude the npm packages of `docs/**`.