### PR TITLE
feat: add dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Our [dependabot](https://github.com/hippocrat-dao/hippo-protocol/security/dependabot) checks all the scope of repo including `docs/**`, which makes the irrelevant noise for our core code. Use dependabot.yml to exclude the npm packages to ignore `docs/**`.

Seems to be `exclude-patterns` not supported any more. https://stackoverflow.com/questions/65275433/can-i-exclude-directories-from-github-dependabot

