### PR TITLE
chore: ignore npm packages for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Dependabot still alert on npm, so clearly ignore it.