### PR TITLE
chore: exclude all npm monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Finally figured out to ignore npm by testing my personal fork.
https://github.com/ChrisCho-H/hippo-protocol