### PR TITLE
wrote test case for root's newApp

### DIFF
--- a/hippod/cmd/root_test.go
+++ b/hippod/cmd/root_test.go
@@ -90,7 +90,7 @@ func TestNewApp(t *testing.T) {
 			server.FlagHaltTime:        uint64(0),
 			server.FlagInterBlockCache: true,
 			server.FlagIndexEvents:     []string{"tx.height", "tx.hash"},
-			server.FlagIAVLCacheSize:   781250, // size of the iavl cache
+			server.FlagIAVLCacheSize:   781250, // size of the IAVL cache
 		},
 	}
 

--- a/hippod/cmd/root_test.go
+++ b/hippod/cmd/root_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"cosmossdk.io/log"
 	cmbtcfg "github.com/cometbft/cometbft/config"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	"github.com/hippocrat-dao/hippo-protocol/app"
@@ -42,4 +46,54 @@ func TestAppExport(t *testing.T) {
 
 	require.Error(t, err)
 	require.NotNil(t, exportedApp)
+}
+
+type mockAppOptions struct {
+	options map[string]interface{}
+}
+
+func (m mockAppOptions) Get(key string) interface{} {
+	if val, ok := m.options[key]; ok {
+		return val
+	}
+	return nil
+}
+
+func setupGenesisFile(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir() // return a new temp dir
+	configDir := filepath.Join(tmpDir, "config")
+	err := os.Mkdir(configDir, 0755) // create a new dir
+	require.NoError(t, err)
+
+	genesisPath := filepath.Join(configDir, "genesis.json")
+	err = os.WriteFile(genesisPath, []byte(`{"chain_id":"test-chain"}`), 0644) // read minimum genesis file
+	require.NoError(t, err)
+
+	return tmpDir
+}
+
+func TestNewApp(t *testing.T) {
+	logger := log.Logger(log.NewNopLogger())
+	db := dbm.NewMemDB()
+	traceStore := new(bytes.Buffer)
+
+	tmpHome := setupGenesisFile(t)
+
+	appOpts := mockAppOptions{
+		options: map[string]interface{}{
+			"home":                     tmpHome,
+			server.FlagPruning:         "nothing",    // or "default" / "everything" / "nothing"
+			server.FlagMinGasPrices:    "0.001uatom", // minimum gas fees
+			server.FlagHaltHeight:      uint64(0),    // no automatic halt
+			server.FlagHaltTime:        uint64(0),
+			server.FlagInterBlockCache: true,
+			server.FlagIndexEvents:     []string{"tx.height", "tx.hash"},
+			server.FlagIAVLCacheSize:   781250, // size of the iavl cache
+		},
+	}
+
+	appInstance := newApp(logger, db, traceStore, appOpts)
+	require.NotNil(t, appInstance, "Should not be nil")
 }


### PR DESCRIPTION
This pull request includes several changes to the `hippod/cmd/root_test.go` file to enhance the test coverage and improve the setup process for tests. The most important changes include adding necessary imports, creating a mock application options type, and setting up a new test for application initialization.

Enhancements to test coverage and setup:

* Added necessary imports for `bytes`, `os`, `path/filepath`, and `github.com/cosmos/cosmos-sdk/server` to support new test functions.
* Created a `mockAppOptions` type to simulate application options for testing purposes. This includes a `Get` method to retrieve option values.
* Added a `setupGenesisFile` function to create a temporary directory and generate a minimal genesis file for testing.
* Introduced a `TestNewApp` function to test the initialization of a new application instance with specific options, ensuring the instance is not nil.