### PR TITLE
update: add keys in secure way

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ in this testnet.
 2. `$ go run hippod/main.go init hippo --chain-id hippo-protocol-testnet-1`. This will initialize a new working directory
    at the default location `~/.hippod`. You need to provide a "moniker" and a "chain id". These
    two names are "hippo" and "hippo-protocol-testnet-1" here. If you want to overwrite just genesis file(not including gentx), add `--overwrite` flag.
-3. `$ go run hippod/main.go keys add alice`. This command will create a new key named alice, using the file backend for secure local key storage.
+3. `$ go run hippod/main.go keys add alice --keyring-backend file`. This command will create a new key named alice, using the file backend for secure local  
+   key storage.
    Make sure to save the output, especially the generated address, as you will need it later during configuration or transactions.
 4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
    before; and `1084734273380000000000000000ahp` is `amount`.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ in this testnet.
 2. `$ go run hippod/main.go init hippo --chain-id hippo-protocol-testnet-1`. This will initialize a new working directory
    at the default location `~/.hippod`. You need to provide a "moniker" and a "chain id". These
    two names are "hippo" and "hippo-protocol-testnet-1" here. If you want to overwrite just genesis file(not including gentx), add `--overwrite` flag.
-3. `$ go run hippod/main.go keys add alice`. This will create a new key, with a name of your choosing(for here, alice).
-   Save the output of this command somewhere; you'll need the address generated here later.
+3. `$ go run hippod/main.go keys add alice`. This command will create a new key named alice, using the file backend for secure local key storage.
+   Make sure to save the output, especially the generated address, as you will need it later during configuration or transactions.
 4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
    before; and `1084734273380000000000000000ahp` is `amount`.
 5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1`. This will create the genesis

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,8 +17,8 @@ in this testnet.
 2. `$ go run hippod/main.go init hippo --chain-id hippo-protocol-testnet-1`. This will initialize a new working directory
    at the default location `~/.hippod`. You need to provide a "moniker" and a "chain id". These
    two names are "hippo" and "hippo-protocol-testnet-1" here. If you want to overwrite just genesis file(not including gentx), add `--overwrite` flag.
-3. `$ go run hippod/main.go keys add alice`. This will create a new key, with a name of your choosing(for here, alice).
-   Save the output of this command somewhere; you'll need the address generated here later.
+3. `$ go run hippod/main.go keys add alice --keyring-backend file`. This command will create a new key named alice, using the file backend for secure local key storage.
+   Make sure to save the output, especially the generated address, as you will need it later during configuration or transactions.
 4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
    before; and `1084734273380000000000000000ahp` is `amount`.
 5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1`. This will create the genesis


### PR DESCRIPTION
This pull request includes updates to the documentation to clarify the creation of a new key using the file backend for secure local key storage. The most important changes are in the `README.md` and `docs/docs/getting-started/installation.md` files.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R20): Updated the instructions for creating a new key to mention the use of the file backend for secure local key storage and emphasized the importance of saving the generated address.
* [`docs/docs/getting-started/installation.md`](diffhunk://#diff-86a5e1e7e6ba037634309d7205a4cc8f03359c76601e155c711b14e6d8eee150L20-R21): Similar update to the instructions for creating a new key, specifying the use of the file backend for secure local key storage and the need to save the generated address.