### PR TITLE
test: improved genaccounts test coverage

### DIFF
--- a/hippod/cmd/genaccounts_test.go
+++ b/hippod/cmd/genaccounts_test.go
@@ -1,106 +1,210 @@
 package cmd_test
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
-
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hippocrat-dao/hippo-protocol/hippod/cmd"
+	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	testcmd "github.com/hippocrat-dao/hippo-protocol/hippod/cmd"
 )
 
-func createMinimalGenesisFile(t *testing.T, home string) {
-	configDir := filepath.Join(home, "config")
-	require.NoError(t, os.MkdirAll(configDir, 0755))
-
-	genesisFile := filepath.Join(configDir, "genesis.json")
-	genesisState := map[string]json.RawMessage{
-		"auth": json.RawMessage(`{"accounts": []}`),
-		"bank": json.RawMessage(`{"balances": [], "supply": "0stake"}`),
-	}
-
-	genDoc := map[string]interface{}{
-		"chain_id":  "test-chain",
-		"app_state": genesisState,
-	}
-	genDocBytes, err := json.MarshalIndent(genDoc, "", "  ")
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(genesisFile, genDocBytes, 0644))
+func mustAccAddress(bytes []byte) sdk.AccAddress {
+	addr := sdk.AccAddress(bytes)
+	return addr
 }
 
-func TestAddGenesisAccountCmd_FullCoverage(t *testing.T) {
+func createGenesisFile(t *testing.T, home string, accounts []authtypes.GenesisAccount, balances []banktypes.Balance) {
+	cdc, _ := newTestCodecAndRegistry()
+
+	packedAccounts, err := authtypes.PackAccounts(accounts)
+	require.NoError(t, err)
+
+	authState := authtypes.GenesisState{
+		Accounts: packedAccounts,
+		Params:   authtypes.DefaultParams(),
+	}
+	authJSON, err := cdc.MarshalJSON(&authState)
+	require.NoError(t, err)
+
+	bankState := banktypes.DefaultGenesisState()
+	bankState.Balances = balances
+	bankJSON, err := cdc.MarshalJSON(bankState)
+	require.NoError(t, err)
+
+	appState := map[string]json.RawMessage{
+		authtypes.ModuleName: authJSON,
+		banktypes.ModuleName: bankJSON,
+	}
+
+	appStateJSON, err := json.Marshal(appState)
+	require.NoError(t, err)
+
+	genDoc := &tmtypes.GenesisDoc{
+		ChainID:         "test-chain",
+		AppState:        appStateJSON,
+		ConsensusParams: tmtypes.DefaultConsensusParams(),
+	}
+
+	configPath := filepath.Join(home, "config")
+	require.NoError(t, os.MkdirAll(configPath, 0755))
+	genFile := filepath.Join(configPath, "genesis.json")
+	require.NoError(t, genDoc.SaveAs(genFile))
+
+	srvCfgPath := filepath.Join(configPath, "config.toml")
+	if _, err := os.Stat(srvCfgPath); os.IsNotExist(err) {
+		require.NoError(t, os.WriteFile(srvCfgPath, []byte("[api]\n"), 0644))
+	}
+}
+
+func newTestCodecAndRegistry() (*codec.ProtoCodec, codectypes.InterfaceRegistry) {
+	registry := codectypes.NewInterfaceRegistry()
+	authtypes.RegisterInterfaces(registry)
+	authvesting.RegisterInterfaces(registry)
+	banktypes.RegisterInterfaces(registry)
+	return codec.NewProtoCodec(registry), registry
+}
+
+func injectClientCtx(cmd *cobra.Command, home string) {
+	cdc, registry := newTestCodecAndRegistry()
+	clientCtx := client.Context{}.
+		WithHomeDir(home).
+		WithCodec(cdc).
+		WithInterfaceRegistry(registry)
+
+	cmd.SetContext(context.WithValue(context.Background(), client.ClientContextKey, &clientCtx))
+}
+
+func TestAddGenesisAccountCmd_Cases(t *testing.T) {
 	home := t.TempDir()
-	createMinimalGenesisFile(t, home)
+	srvCtx := server.NewDefaultContext()
+	srvCtx.Config.RootDir = home
 
-	tests := []struct {
-		name        string
-		args        []string
-		expectErr   bool
-		errContains string
-	}{
-		{
-			name:      "Invalid coins",
-			args:      []string{"cosmos1xx", "invalidcoin", "--home", home},
-			expectErr: true,
-		},
-		{
-			name:        "Vesting amount > total",
-			args:        []string{"cosmos1xx", "50stake", "--home", home, "--vesting-amount", "100stake", "--vesting-end-time", "10000"},
-			expectErr:   true,
-			errContains: "vesting amount cannot be greater",
-		},
-		{
-			name: "Continuous vesting",
-			args: []string{"cosmos1abc", "100stake", "--home", home, "--vesting-amount", "50stake", "--vesting-start-time", "1000", "--vesting-end-time", "2000"},
-		},
-		{
-			name: "Delayed vesting",
-			args: []string{"cosmos1def", "100stake", "--home", home, "--vesting-amount", "50stake", "--vesting-end-time", "3000"},
-		},
-		{
-			name:        "Missing vesting params",
-			args:        []string{"cosmos1vest", "100stake", "--home", home, "--vesting-amount", "50stake"},
-			expectErr:   true,
-			errContains: "invalid vesting parameters",
-		},
-		{
-			name: "Successful account",
-			args: []string{"cosmos1success", "100stake", "--home", home},
-		},
-		{
-			name: "Append to existing account",
-			args: []string{"cosmos1success", "50stake", "--home", home, "--append"},
-		},
-		{
-			name:        "Duplicate without append",
-			args:        []string{"cosmos1success", "50stake", "--home", home},
-			expectErr:   true,
-			errContains: "cannot add account at existing address",
-		},
-		{
-			name:        "Invalid vesting coins",
-			args:        []string{"cosmos1failvest", "100stake", "--home", home, "--vesting-amount", "badcoin"},
-			expectErr:   true,
-			errContains: "failed to parse vesting amount",
-		},
-	}
+	addr := mustAccAddress([]byte("testaddr000000000000000000000000000001")).String()
+	coins := "100stake"
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := cmd.AddGenesisAccountCmd(home)
-			cmd.SetArgs(tt.args)
-			err := cmd.Execute()
-			if tt.expectErr {
-				require.Error(t, err)
-				if tt.errContains != "" {
-					require.Contains(t, err.Error(), tt.errContains)
-				}
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	t.Run("New account", func(t *testing.T) {
+		createGenesisFile(t, home, []authtypes.GenesisAccount{}, []banktypes.Balance{})
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{addr, coins, "--home", home}
+		require.NoError(t, cmd.ParseFlags(args))
+		injectClientCtx(cmd, home)
+		viper.Set(flags.FlagHome, home)
+		require.NoError(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Append to existing", func(t *testing.T) {
+		acc := authtypes.NewBaseAccount(mustAccAddress([]byte("testaddrappend")), nil, 0, 0)
+		balance := banktypes.Balance{
+			Address: acc.GetAddress().String(),
+			Coins:   sdk.NewCoins(sdk.NewInt64Coin("stake", 50)),
+		}
+		createGenesisFile(t, home, []authtypes.GenesisAccount{acc}, []banktypes.Balance{balance})
+
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{acc.GetAddress().String(), coins, "--home", home, "--append"}
+
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+
+		require.NoError(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Invalid Bech32", func(t *testing.T) {
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{"invalid_addr_%%%", coins, "--home", home}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.Error(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Invalid coins format", func(t *testing.T) {
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{addr, "invalidcoin!", "--home", home}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.Error(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Vesting > balance", func(t *testing.T) {
+		createGenesisFile(t, home, []authtypes.GenesisAccount{}, []banktypes.Balance{})
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{
+			addr, coins,
+			"--home", home,
+			"--vesting-amount", "150stake",
+			"--vesting-end-time", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()),
+		}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.ErrorContains(t, cmd.RunE(cmd, args[:2]), "vesting amount cannot be greater")
+	})
+
+	t.Run("Continuous vesting", func(t *testing.T) {
+		createGenesisFile(t, home, []authtypes.GenesisAccount{}, []banktypes.Balance{})
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{
+			addr, coins,
+			"--home", home,
+			"--vesting-amount", "50stake",
+			"--vesting-start-time", fmt.Sprintf("%d", time.Now().Unix()),
+			"--vesting-end-time", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()),
+		}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.NoError(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Delayed vesting", func(t *testing.T) {
+		createGenesisFile(t, home, []authtypes.GenesisAccount{}, []banktypes.Balance{})
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{
+			addr, coins,
+			"--home", home,
+			"--vesting-amount", "50stake",
+			"--vesting-end-time", fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix()),
+		}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.NoError(t, cmd.RunE(cmd, args[:2]))
+	})
+
+	t.Run("Invalid vesting params", func(t *testing.T) {
+		cmd := testcmd.AddGenesisAccountCmd(home)
+		args := []string{
+			addr, coins,
+			"--home", home,
+			"--vesting-amount", "10stake",
+		}
+		require.NoError(t, cmd.ParseFlags(args))
+		viper.Set(flags.FlagHome, home)
+		injectClientCtx(cmd, home)
+		require.ErrorContains(t, cmd.RunE(cmd, args[:2]), "invalid vesting parameters")
+	})
 }

--- a/hippod/cmd/genaccounts_test.go
+++ b/hippod/cmd/genaccounts_test.go
@@ -95,7 +95,7 @@ func injectClientCtx(cmd *cobra.Command, home string) {
 	cmd.SetContext(context.WithValue(context.Background(), client.ClientContextKey, &clientCtx))
 }
 
-func TestAddGenesisAccountCmd_Cases(t *testing.T) {
+func TestAddGenesisAccountCmd(t *testing.T) {
 	home := t.TempDir()
 	srvCtx := server.NewDefaultContext()
 	srvCtx.Config.RootDir = home


### PR DESCRIPTION
This pull request includes changes to the `hippod/cmd/genaccounts_test.go` file to improve the organization and coverage of the tests. The most important changes include reorganizing the package structure, enhancing test coverage, and refining the test cases.

### Reorganization and Test Coverage Enhancements:

* Changed the package declaration from `cmd` to `cmd_test` to follow Go's best practices for testing.
* Refactored the `TestAddGenesisAccountCmd` function to `TestAddGenesisAccountCmd_FullCoverage` and added multiple test cases to cover various scenarios, including invalid coins, vesting parameters, and successful account creation.

These changes improve the maintainability and reliability of the tests by ensuring a more comprehensive coverage of different scenarios.