### PR TITLE
test: init test cases updates with real cases for improve %

### DIFF
--- a/hippod/cmd/init_test.go
+++ b/hippod/cmd/init_test.go
@@ -1,18 +1,26 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"cosmossdk.io/math"
-	"github.com/cometbft/cometbft/types"
-	cmttypes "github.com/cometbft/cometbft/types"
+	auth "github.com/cosmos/cosmos-sdk/x/auth"
+	bank "github.com/cosmos/cosmos-sdk/x/bank"
+	mint "github.com/cosmos/cosmos-sdk/x/mint"
+	staking "github.com/cosmos/cosmos-sdk/x/staking"
+
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
@@ -20,302 +28,127 @@ import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/hippocrat-dao/hippo-protocol/app"
-	"github.com/hippocrat-dao/hippo-protocol/test"
-	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
-	"github.com/spf13/cobra"
+	distribution "github.com/cosmos/cosmos-sdk/x/distribution"
+	gov "github.com/cosmos/cosmos-sdk/x/gov"
+	slashing "github.com/cosmos/cosmos-sdk/x/slashing"
+
+	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
-var homeDir string
-var chainID string
-var defaultDenom string
+func makeTestEncodingConfig() codec.Codec {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	authtypes.RegisterInterfaces(interfaceRegistry)
+	authvesting.RegisterInterfaces(interfaceRegistry)
+	banktypes.RegisterInterfaces(interfaceRegistry)
+	govv1types.RegisterInterfaces(interfaceRegistry)
+	minttypes.RegisterInterfaces(interfaceRegistry)
+	stakingtypes.RegisterInterfaces(interfaceRegistry)
+	slashingtypes.RegisterInterfaces(interfaceRegistry)
+	distrtypes.RegisterInterfaces(interfaceRegistry)
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize the node",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if homeDir == "" {
-			return fmt.Errorf("home directory is required")
-		}
-		return nil
-	},
+	return codec.NewProtoCodec(interfaceRegistry)
 }
 
-func init() {
-	initCmd.Flags().StringVar(&homeDir, "home", "./test_home", "node's home directory")
-	initCmd.Flags().StringVar(&chainID, "chain-id", "test-chain", "The chain ID to initialize")
-	initCmd.Flags().StringVar(&defaultDenom, "default-denom", "stake", "Default denomination for the chain")
+func TestInitCmd_Basic(t *testing.T) {
+	home := t.TempDir()
+	defaultNodeHome := home
+	viper.Set("home", home)
+
+	basicManager := module.NewBasicManager(
+		auth.AppModuleBasic{},
+		bank.AppModuleBasic{},
+		staking.AppModuleBasic{},
+		mint.AppModuleBasic{},
+		gov.AppModuleBasic{},
+		slashing.AppModuleBasic{},
+		distribution.AppModuleBasic{},
+	)
+
+	command := InitCmd(basicManager, defaultNodeHome)
+	command.SetArgs([]string{"hippo-moniker", "--home", home, "--overwrite"})
+
+	configPath := filepath.Join(home, "config")
+	require.NoError(t, os.MkdirAll(configPath, 0755))
+
+	srvCtx := server.NewDefaultContext()
+	srvCtx.Config.RootDir = home
+	clientCtx := client.Context{}.WithHomeDir(home).WithCodec(makeTestEncodingConfig())
+
+	command.SetContext(context.WithValue(
+		context.WithValue(context.Background(), server.ServerContextKey, srvCtx),
+		client.ClientContextKey, &clientCtx,
+	))
+
+	require.NoError(t, command.Execute())
+
+	expectedFiles := []string{
+		"genesis.json",
+		"node_key.json",
+		"priv_validator_key.json",
+	}
+
+	for _, f := range expectedFiles {
+		_, err := os.Stat(filepath.Join(configPath, f))
+		require.NoError(t, err, "%s should exist", f)
+	}
 }
 
-func setupTestEnvironment(t *testing.T, configPath string) {
-	err := os.MkdirAll(configPath, os.ModePerm)
-	require.NoError(t, err)
+func TestInitCmd_RecoverMnemonic_Invalid(t *testing.T) {
+	home := t.TempDir()
+	defaultNodeHome := home
+	basicManager := module.NewBasicManager()
 
-	err = os.WriteFile(configPath+"/genesis.json", []byte(`{"chain_id": "test-chain"}`), 0644)
-	require.NoError(t, err)
+	command := InitCmd(basicManager, defaultNodeHome)
+	command.SetArgs([]string{"hippo-moniker", "--home", home, "--recover"})
 
-	err = os.WriteFile(configPath+"/node_key.json", []byte(`{"node_key": "test"}`), 0644)
-	require.NoError(t, err)
-}
-
-func cleanupTestEnvironment(t *testing.T, configPath string) {
-	err := os.RemoveAll(configPath)
-	require.NoError(t, err)
-}
-
-func TestInitCmd(t *testing.T) {
-	configPath := "./test_home/config"
-	setupTestEnvironment(t, configPath)
-	defer cleanupTestEnvironment(t, configPath)
-
-	t.Run("Test_valid_init_command", func(t *testing.T) {
-		initCmd.SetArgs([]string{"--home", "./test_home", "--chain-id", "test-chain"})
-		err := initCmd.Execute()
-		require.NoError(t, err)
-	})
-
-	t.Run("Test_invalid_mnemonic", func(t *testing.T) {
-		initCmd.SetArgs([]string{"--home", "./test_home", "--mnemonic", "invalid"})
-		err := initCmd.Execute()
-		require.Error(t, err)
-	})
-
-	t.Run("Test_custom_denom", func(t *testing.T) {
-		initCmd.SetArgs([]string{"--home", "./test_home", "--default-denom", "custom-denom"})
-		err := initCmd.Execute()
-		require.NoError(t, err)
-	})
-}
-
-func TestActualInitCmd(t *testing.T) {
-	hippoApp := test.GetApp()
-	// Create a dummy module basic manager
-	mbm := hippoApp.BasicModuleManager
-
-	// Create the InitCmd
-	cmd := InitCmd(mbm, app.DefaultNodeHome)
-
-	// Set command flags
-	cmd.SetArgs([]string{"test-moniker", "--chain-id", "test-chain-123"})
-
-	// Execute the command
-	err := cmd.Execute()
-	require.Error(t, err)
-
-	// Verify that the genesis.json file was created
-	genesisFile := filepath.Join(app.DefaultNodeHome, "config", "genesis.json")
-	_, err = os.Stat(genesisFile)
-	require.Error(t, err)
-
-	// Read and verify the genesis.json file
-	genesisDoc, err := types.GenesisDocFromFile(genesisFile)
-	require.Error(t, err)
-	require.Nil(t, genesisDoc)
-
-	// Verify the config.toml file was created
-	configFile := filepath.Join(app.DefaultNodeHome, "config", "config.toml")
-	_, err = os.Stat(configFile)
-	require.Error(t, err)
-
-	// Test overwrite flag
-	cmdOverwrite := InitCmd(mbm, app.DefaultNodeHome)
-	cmdOverwrite.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "-o"})
-	err = cmdOverwrite.Execute()
-	require.Error(t, err)
-
-	//Test recover flag
-	cmdRecover := InitCmd(mbm, app.DefaultNodeHome)
-	cmdRecover.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "--recover"})
-
-	//Mock stdin to provide mnemonic
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
-	cmdRecover.SetIn(r)
-	_, err = w.WriteString("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n")
+	command.SetIn(r)
+	_, err = w.WriteString("invalid mnemonic phrase\n")
 	require.NoError(t, err)
 	w.Close()
 
-	err = cmdRecover.Execute()
+	srvCtx := server.NewDefaultContext()
+	srvCtx.Config.RootDir = home
+	clientCtx := client.Context{}.WithHomeDir(home).WithCodec(makeTestEncodingConfig())
+	command.SetContext(context.WithValue(
+		context.WithValue(context.Background(), server.ServerContextKey, srvCtx),
+		client.ClientContextKey, &clientCtx,
+	))
+
+	err = command.Execute()
 	require.Error(t, err)
-
-	// Test default bond denom flag
-	cmdDenom := InitCmd(mbm, app.DefaultNodeHome)
-	cmdDenom.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "--default-bond-denom", "testdenom"})
-
-	err = cmdDenom.Execute()
-	require.Error(t, err)
-
-	require.NotEqual(t, "testdenom", sdk.DefaultBondDenom)
+	require.Contains(t, err.Error(), "invalid mnemonic")
 }
 
-func TestOverrideGenesis(t *testing.T) {
-	hippoApp := test.GetApp()
-	appGenState := hippoApp.DefaultGenesis()
-	appCodec := hippoApp.AppCodec()
-
-	genDoc := &cmttypes.GenesisDoc{}
-	genDoc.ChainID = chainID
-	genDoc.Validators = nil
-	genDoc.InitialHeight = 0
-	genDoc.ConsensusParams = &cmttypes.ConsensusParams{
-		Block:     cmttypes.DefaultBlockParams(),
-		Evidence:  cmttypes.DefaultEvidenceParams(),
-		Validator: cmttypes.DefaultValidatorParams(),
-		Version:   cmttypes.DefaultVersionParams(),
+func TestOverrideGenesis_Valid(t *testing.T) {
+	cdc := makeTestEncodingConfig()
+	appState := map[string]json.RawMessage{
+		stakingtypes.ModuleName:  cdc.MustMarshalJSON(stakingtypes.DefaultGenesisState()),
+		minttypes.ModuleName:     cdc.MustMarshalJSON(minttypes.DefaultGenesisState()),
+		distrtypes.ModuleName:    cdc.MustMarshalJSON(distrtypes.DefaultGenesisState()),
+		slashingtypes.ModuleName: cdc.MustMarshalJSON(slashingtypes.DefaultGenesisState()),
+		govtypes.ModuleName:      cdc.MustMarshalJSON(govv1types.DefaultGenesisState()),
+	}
+	genDoc := &tmtypes.GenesisDoc{
+		ConsensusParams: tmtypes.DefaultConsensusParams(),
 	}
 
-	appStateJson, err := overrideGenesis(appCodec, genDoc, appGenState)
+	_, err := overrideGenesis(cdc, genDoc, appState)
 	require.NoError(t, err)
-	genDoc.AppState = appStateJson
-	require.NoError(t, err)
-
-	// Verify consensus params
-	require.Equal(t, consensus.MaxBlockSize, int(genDoc.ConsensusParams.Block.MaxBytes))
-	require.Equal(t, consensus.MaxBlockGas, int(genDoc.ConsensusParams.Block.MaxGas))
-	require.Equal(t, consensus.MaxAgeDuration, time.Duration(genDoc.ConsensusParams.Evidence.MaxAgeDuration))
-	require.Equal(t, consensus.MaxAgeNumBlocks, uint64(genDoc.ConsensusParams.Evidence.MaxAgeNumBlocks))
-
-	var appState map[string]json.RawMessage
-	err = json.Unmarshal(appStateJson, &appState)
-	require.NoError(t, err)
-
-	// Verify staking genesis state
-	var updatedStakingGenState stakingtypes.GenesisState
-	err = appCodec.UnmarshalJSON(appState[stakingtypes.ModuleName], &updatedStakingGenState)
-	require.NoError(t, err)
-
-	require.Equal(t, consensus.UnbondingPeriod, updatedStakingGenState.Params.UnbondingTime)
-	require.Equal(t, consensus.MaxValidators, int(updatedStakingGenState.Params.MaxValidators))
-	require.Equal(t, consensus.DefaultHippoDenom, updatedStakingGenState.Params.BondDenom)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.MinCommissionRate, 2), updatedStakingGenState.Params.MinCommissionRate)
-
-	// Verify mint genesis state
-	var updatedMintGenState minttypes.GenesisState
-	err = appCodec.UnmarshalJSON(appState[minttypes.ModuleName], &updatedMintGenState)
-	require.NoError(t, err)
-
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.Minter, 2), updatedMintGenState.Minter.Inflation)
-	require.Equal(t, consensus.DefaultHippoDenom, updatedMintGenState.Params.MintDenom)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationRateChange, 2), updatedMintGenState.Params.InflationRateChange)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationMin, 2), updatedMintGenState.Params.InflationMin)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationMax, 2), updatedMintGenState.Params.InflationMax)
-	require.Equal(t, consensus.BlocksPerYear, updatedMintGenState.Params.BlocksPerYear)
-
-	//Verify distribution genesis state
-	var updatedDistrGenState distrtypes.GenesisState
-	err = appCodec.UnmarshalJSON(appState[distrtypes.ModuleName], &updatedDistrGenState)
-	require.NoError(t, err)
-
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.CommunityTax, 2), updatedDistrGenState.Params.CommunityTax)
-
-	//verify gov genesis state
-	var updatedGovGenState govv1types.GenesisState
-	err = appCodec.UnmarshalJSON(appState[govtypes.ModuleName], &updatedGovGenState)
-	require.NoError(t, err)
-
-	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction)
-	require.Equal(t, sdk.NewCoin(consensus.DefaultHippoDenom, minDepositTokens), updatedGovGenState.Params.MinDeposit[0])
-	require.Equal(t, 1, len(updatedGovGenState.Params.MinDeposit)) // check ahp is the only registered
-	require.Equal(t, consensus.MaxDepositPeriod, *updatedGovGenState.Params.MaxDepositPeriod)
-	require.Equal(t, consensus.VotingPeriod, *updatedGovGenState.Params.VotingPeriod)
-
-	//verify slashing genesis state
-	var updatedSlashingGenState slashingtypes.GenesisState
-	err = appCodec.UnmarshalJSON(appState[slashingtypes.ModuleName], &updatedSlashingGenState)
-	require.NoError(t, err)
-
-	require.Equal(t, consensus.SignedBlocksWindow, int(updatedSlashingGenState.Params.SignedBlocksWindow))
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.MinSignedPerWindow, 2), updatedSlashingGenState.Params.MinSignedPerWindow)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.SlashFractionDoubleSign, 2), updatedSlashingGenState.Params.SlashFractionDoubleSign)
-	require.Equal(t, math.LegacyNewDecWithPrec(consensus.SlashFractionDowntime*100, 4), updatedSlashingGenState.Params.SlashFractionDowntime)
-
-}
-
-func TestFlags(t *testing.T) {
-	require.Equal(t, "overwrite", FlagOverwrite)
-	require.Equal(t, "recover", FlagRecover)
-	require.Equal(t, "default-denom", FlagDefaultBondDenom)
-	require.Equal(t, "staking-bond-denom", FlagStakingBondDenom)
-}
-
-func TestNewPrintInfo(t *testing.T) {
-	moniker := "moniker"
-	chainID := "chainID"
-	nodeID := "nodeID"
-	genTxsDir := "genTxsDir"
-	appMessage := json.RawMessage(`{"name": "John", "age": 30}`)
-
-	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
-
-	require.Equal(t, moniker, printInfo.Moniker)
-	require.Equal(t, chainID, printInfo.ChainID)
-	require.Equal(t, nodeID, printInfo.NodeID)
-	require.Equal(t, genTxsDir, printInfo.GenTxsDir)
-	require.Equal(t, appMessage, printInfo.AppMessage)
 }
 
 func TestDisplayInfo(t *testing.T) {
-	moniker := "moniker"
-	chainID := "chainID"
-	nodeID := "nodeID"
-	genTxsDir := "genTxsDir"
-	appMessage := json.RawMessage(`{"name": "John", "age": 30}`)
-
-	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
-	err := displayInfo(printInfo)
-
-	require.NoError(t, err)
-}
-
-func TestFailingOverrideGenesis(t *testing.T) {
-	getParam := func(key string) (codec.JSONCodec, *cmttypes.GenesisDoc, map[string]json.RawMessage) {
-		hippoApp := test.GetApp()
-		appGenState := hippoApp.DefaultGenesis()
-		appCodec := hippoApp.AppCodec()
-
-		genDoc := &cmttypes.GenesisDoc{}
-		genDoc.ChainID = chainID
-		genDoc.Validators = nil
-		genDoc.InitialHeight = 0
-		genDoc.ConsensusParams = &cmttypes.ConsensusParams{
-			Block:     cmttypes.DefaultBlockParams(),
-			Evidence:  cmttypes.DefaultEvidenceParams(),
-			Validator: cmttypes.DefaultValidatorParams(),
-			Version:   cmttypes.DefaultVersionParams(),
-		}
-
-		delete(appGenState, key)
-
-		return appCodec, genDoc, appGenState
+	info := printInfo{
+		Moniker:    "hippo",
+		ChainID:    "hippo-1",
+		NodeID:     "node123",
+		GenTxsDir:  "",
+		AppMessage: json.RawMessage(`{"foo":"bar"}`),
 	}
 
-	_, err := overrideGenesis(getParam("staking"))
-	require.Error(t, err)
-
-	_, err = overrideGenesis(getParam("mint"))
-	require.Error(t, err)
-
-	_, err = overrideGenesis(getParam("distribution"))
-	require.Error(t, err)
-
-	_, err = overrideGenesis(getParam("gov"))
-	require.Error(t, err)
-
-	_, err = overrideGenesis(getParam("slashing"))
-	require.Error(t, err)
-
-}
-
-func TestFailingDisplayInfo(t *testing.T) {
-	moniker := ""
-	chainID := ""
-	nodeID := ""
-	genTxsDir := ""
-	appMessage := json.RawMessage("")
-
-	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
-	err := displayInfo(printInfo)
-
-	require.Error(t, err)
+	err := displayInfo(info)
+	require.NoError(t, err)
 }

--- a/hippod/cmd/init_test.go
+++ b/hippod/cmd/init_test.go
@@ -3,39 +3,83 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
-	auth "github.com/cosmos/cosmos-sdk/x/auth"
-	bank "github.com/cosmos/cosmos-sdk/x/bank"
-	mint "github.com/cosmos/cosmos-sdk/x/mint"
-	staking "github.com/cosmos/cosmos-sdk/x/staking"
-
+	"cosmossdk.io/math"
+	cmttypes "github.com/cometbft/cometbft/types"
+	cometbfttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/mint"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/hippocrat-dao/hippo-protocol/app"
+	"github.com/hippocrat-dao/hippo-protocol/test"
+	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
-	distribution "github.com/cosmos/cosmos-sdk/x/distribution"
-	gov "github.com/cosmos/cosmos-sdk/x/gov"
-	slashing "github.com/cosmos/cosmos-sdk/x/slashing"
-
-	tmtypes "github.com/cometbft/cometbft/types"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 )
+
+var homeDir string
+var chainID string
+var defaultDenom string
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize the node",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if homeDir == "" {
+			return fmt.Errorf("home directory is required")
+		}
+		return nil
+	},
+}
+
+func init() {
+	initCmd.Flags().StringVar(&homeDir, "home", "./test_home", "node's home directory")
+	initCmd.Flags().StringVar(&chainID, "chain-id", "test-chain", "The chain ID to initialize")
+	initCmd.Flags().StringVar(&defaultDenom, "default-denom", "stake", "Default denomination for the chain")
+}
+
+func setupTestEnvironment(t *testing.T, configPath string) {
+	err := os.MkdirAll(configPath, os.ModePerm)
+	require.NoError(t, err)
+
+	err = os.WriteFile(configPath+"/genesis.json", []byte(`{"chain_id": "test-chain"}`), 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(configPath+"/node_key.json", []byte(`{"node_key": "test"}`), 0644)
+	require.NoError(t, err)
+}
+
+func cleanupTestEnvironment(t *testing.T, configPath string) {
+	err := os.RemoveAll(configPath)
+	require.NoError(t, err)
+}
 
 func makeTestEncodingConfig() codec.Codec {
 	interfaceRegistry := types.NewInterfaceRegistry()
@@ -51,7 +95,7 @@ func makeTestEncodingConfig() codec.Codec {
 	return codec.NewProtoCodec(interfaceRegistry)
 }
 
-func TestInitCmd_Basic(t *testing.T) {
+func TestInitCmd(t *testing.T) {
 	home := t.TempDir()
 	defaultNodeHome := home
 	viper.Set("home", home)
@@ -123,32 +167,234 @@ func TestInitCmd_RecoverMnemonic_Invalid(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid mnemonic")
 }
 
-func TestOverrideGenesis_Valid(t *testing.T) {
-	cdc := makeTestEncodingConfig()
-	appState := map[string]json.RawMessage{
-		stakingtypes.ModuleName:  cdc.MustMarshalJSON(stakingtypes.DefaultGenesisState()),
-		minttypes.ModuleName:     cdc.MustMarshalJSON(minttypes.DefaultGenesisState()),
-		distrtypes.ModuleName:    cdc.MustMarshalJSON(distrtypes.DefaultGenesisState()),
-		slashingtypes.ModuleName: cdc.MustMarshalJSON(slashingtypes.DefaultGenesisState()),
-		govtypes.ModuleName:      cdc.MustMarshalJSON(govv1types.DefaultGenesisState()),
-	}
-	genDoc := &tmtypes.GenesisDoc{
-		ConsensusParams: tmtypes.DefaultConsensusParams(),
+func TestActualInitCmd(t *testing.T) {
+	hippoApp := test.GetApp()
+	// Create a dummy module basic manager
+	mbm := hippoApp.BasicModuleManager
+
+	// Create the InitCmd
+	cmd := InitCmd(mbm, app.DefaultNodeHome)
+
+	// Set command flags
+	cmd.SetArgs([]string{"test-moniker", "--chain-id", "test-chain-123"})
+
+	// Execute the command
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	// Verify that the genesis.json file was created
+	genesisFile := filepath.Join(app.DefaultNodeHome, "config", "genesis.json")
+	_, err = os.Stat(genesisFile)
+	require.Error(t, err)
+
+	// Read and verify the genesis.json file
+	genesisDoc, err := cometbfttypes.GenesisDocFromFile(genesisFile)
+	require.Error(t, err)
+	require.Nil(t, genesisDoc)
+
+	// Verify the config.toml file was created
+	configFile := filepath.Join(app.DefaultNodeHome, "config", "config.toml")
+	_, err = os.Stat(configFile)
+	require.Error(t, err)
+
+	// Test overwrite flag
+	cmdOverwrite := InitCmd(mbm, app.DefaultNodeHome)
+	cmdOverwrite.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "-o"})
+	err = cmdOverwrite.Execute()
+	require.Error(t, err)
+
+	//Test recover flag
+	cmdRecover := InitCmd(mbm, app.DefaultNodeHome)
+	cmdRecover.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "--recover"})
+
+	//Mock stdin to provide mnemonic
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	cmdRecover.SetIn(r)
+	_, err = w.WriteString("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\n")
+	require.NoError(t, err)
+	w.Close()
+
+	err = cmdRecover.Execute()
+	require.Error(t, err)
+
+	// Test default bond denom flag
+	cmdDenom := InitCmd(mbm, app.DefaultNodeHome)
+	cmdDenom.SetArgs([]string{"test-moniker", "--home", app.DefaultNodeHome, "--chain-id", "test-chain-123", "--default-bond-denom", "testdenom"})
+
+	err = cmdDenom.Execute()
+	require.Error(t, err)
+
+	require.NotEqual(t, "testdenom", sdk.DefaultBondDenom)
+}
+
+func TestOverrideGenesis(t *testing.T) {
+	hippoApp := test.GetApp()
+	appGenState := hippoApp.DefaultGenesis()
+	appCodec := hippoApp.AppCodec()
+
+	genDoc := &cmttypes.GenesisDoc{}
+	genDoc.ChainID = chainID
+	genDoc.Validators = nil
+	genDoc.InitialHeight = 0
+	genDoc.ConsensusParams = &cmttypes.ConsensusParams{
+		Block:     cmttypes.DefaultBlockParams(),
+		Evidence:  cmttypes.DefaultEvidenceParams(),
+		Validator: cmttypes.DefaultValidatorParams(),
+		Version:   cmttypes.DefaultVersionParams(),
 	}
 
-	_, err := overrideGenesis(cdc, genDoc, appState)
+	appStateJson, err := overrideGenesis(appCodec, genDoc, appGenState)
 	require.NoError(t, err)
+	genDoc.AppState = appStateJson
+	require.NoError(t, err)
+
+	// Verify consensus params
+	require.Equal(t, consensus.MaxBlockSize, int(genDoc.ConsensusParams.Block.MaxBytes))
+	require.Equal(t, consensus.MaxBlockGas, int(genDoc.ConsensusParams.Block.MaxGas))
+	require.Equal(t, consensus.MaxAgeDuration, time.Duration(genDoc.ConsensusParams.Evidence.MaxAgeDuration))
+	require.Equal(t, consensus.MaxAgeNumBlocks, uint64(genDoc.ConsensusParams.Evidence.MaxAgeNumBlocks))
+
+	var appState map[string]json.RawMessage
+	err = json.Unmarshal(appStateJson, &appState)
+	require.NoError(t, err)
+
+	// Verify staking genesis state
+	var updatedStakingGenState stakingtypes.GenesisState
+	err = appCodec.UnmarshalJSON(appState[stakingtypes.ModuleName], &updatedStakingGenState)
+	require.NoError(t, err)
+
+	require.Equal(t, consensus.UnbondingPeriod, updatedStakingGenState.Params.UnbondingTime)
+	require.Equal(t, consensus.MaxValidators, int(updatedStakingGenState.Params.MaxValidators))
+	require.Equal(t, consensus.DefaultHippoDenom, updatedStakingGenState.Params.BondDenom)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.MinCommissionRate, 2), updatedStakingGenState.Params.MinCommissionRate)
+
+	// Verify mint genesis state
+	var updatedMintGenState minttypes.GenesisState
+	err = appCodec.UnmarshalJSON(appState[minttypes.ModuleName], &updatedMintGenState)
+	require.NoError(t, err)
+
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.Minter, 2), updatedMintGenState.Minter.Inflation)
+	require.Equal(t, consensus.DefaultHippoDenom, updatedMintGenState.Params.MintDenom)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationRateChange, 2), updatedMintGenState.Params.InflationRateChange)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationMin, 2), updatedMintGenState.Params.InflationMin)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.InflationMax, 2), updatedMintGenState.Params.InflationMax)
+	require.Equal(t, consensus.BlocksPerYear, updatedMintGenState.Params.BlocksPerYear)
+
+	//Verify distribution genesis state
+	var updatedDistrGenState distrtypes.GenesisState
+	err = appCodec.UnmarshalJSON(appState[distrtypes.ModuleName], &updatedDistrGenState)
+	require.NoError(t, err)
+
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.CommunityTax, 2), updatedDistrGenState.Params.CommunityTax)
+
+	//verify gov genesis state
+	var updatedGovGenState govv1types.GenesisState
+	err = appCodec.UnmarshalJSON(appState[govtypes.ModuleName], &updatedGovGenState)
+	require.NoError(t, err)
+
+	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction)
+	require.Equal(t, sdk.NewCoin(consensus.DefaultHippoDenom, minDepositTokens), updatedGovGenState.Params.MinDeposit[0])
+	require.Equal(t, 1, len(updatedGovGenState.Params.MinDeposit)) // check ahp is the only registered
+	require.Equal(t, consensus.MaxDepositPeriod, *updatedGovGenState.Params.MaxDepositPeriod)
+	require.Equal(t, consensus.VotingPeriod, *updatedGovGenState.Params.VotingPeriod)
+
+	//verify slashing genesis state
+	var updatedSlashingGenState slashingtypes.GenesisState
+	err = appCodec.UnmarshalJSON(appState[slashingtypes.ModuleName], &updatedSlashingGenState)
+	require.NoError(t, err)
+
+	require.Equal(t, consensus.SignedBlocksWindow, int(updatedSlashingGenState.Params.SignedBlocksWindow))
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.MinSignedPerWindow, 2), updatedSlashingGenState.Params.MinSignedPerWindow)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.SlashFractionDoubleSign, 2), updatedSlashingGenState.Params.SlashFractionDoubleSign)
+	require.Equal(t, math.LegacyNewDecWithPrec(consensus.SlashFractionDowntime*100, 4), updatedSlashingGenState.Params.SlashFractionDowntime)
+
+}
+
+func TestFlags(t *testing.T) {
+	require.Equal(t, "overwrite", FlagOverwrite)
+	require.Equal(t, "recover", FlagRecover)
+	require.Equal(t, "default-denom", FlagDefaultBondDenom)
+	require.Equal(t, "staking-bond-denom", FlagStakingBondDenom)
+}
+
+func TestNewPrintInfo(t *testing.T) {
+	moniker := "moniker"
+	chainID := "chainID"
+	nodeID := "nodeID"
+	genTxsDir := "genTxsDir"
+	appMessage := json.RawMessage(`{"name": "John", "age": 30}`)
+
+	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
+
+	require.Equal(t, moniker, printInfo.Moniker)
+	require.Equal(t, chainID, printInfo.ChainID)
+	require.Equal(t, nodeID, printInfo.NodeID)
+	require.Equal(t, genTxsDir, printInfo.GenTxsDir)
+	require.Equal(t, appMessage, printInfo.AppMessage)
 }
 
 func TestDisplayInfo(t *testing.T) {
-	info := printInfo{
-		Moniker:    "hippo",
-		ChainID:    "hippo-1",
-		NodeID:     "node123",
-		GenTxsDir:  "",
-		AppMessage: json.RawMessage(`{"foo":"bar"}`),
+	moniker := "moniker"
+	chainID := "chainID"
+	nodeID := "nodeID"
+	genTxsDir := "genTxsDir"
+	appMessage := json.RawMessage(`{"name": "John", "age": 30}`)
+
+	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
+	err := displayInfo(printInfo)
+
+	require.NoError(t, err)
+}
+
+func TestFailingOverrideGenesis(t *testing.T) {
+	getParam := func(key string) (codec.JSONCodec, *cmttypes.GenesisDoc, map[string]json.RawMessage) {
+		hippoApp := test.GetApp()
+		appGenState := hippoApp.DefaultGenesis()
+		appCodec := hippoApp.AppCodec()
+
+		genDoc := &cmttypes.GenesisDoc{}
+		genDoc.ChainID = chainID
+		genDoc.Validators = nil
+		genDoc.InitialHeight = 0
+		genDoc.ConsensusParams = &cmttypes.ConsensusParams{
+			Block:     cmttypes.DefaultBlockParams(),
+			Evidence:  cmttypes.DefaultEvidenceParams(),
+			Validator: cmttypes.DefaultValidatorParams(),
+			Version:   cmttypes.DefaultVersionParams(),
+		}
+
+		delete(appGenState, key)
+
+		return appCodec, genDoc, appGenState
 	}
 
-	err := displayInfo(info)
-	require.NoError(t, err)
+	_, err := overrideGenesis(getParam("staking"))
+	require.Error(t, err)
+
+	_, err = overrideGenesis(getParam("mint"))
+	require.Error(t, err)
+
+	_, err = overrideGenesis(getParam("distribution"))
+	require.Error(t, err)
+
+	_, err = overrideGenesis(getParam("gov"))
+	require.Error(t, err)
+
+	_, err = overrideGenesis(getParam("slashing"))
+	require.Error(t, err)
+
+}
+
+func TestFailingDisplayInfo(t *testing.T) {
+	moniker := ""
+	chainID := ""
+	nodeID := ""
+	genTxsDir := ""
+	appMessage := json.RawMessage("")
+
+	printInfo := newPrintInfo(moniker, chainID, nodeID, genTxsDir, appMessage)
+	err := displayInfo(printInfo)
+
+	require.Error(t, err)
 }

--- a/hippod/cmd/init_test.go
+++ b/hippod/cmd/init_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"cosmossdk.io/x/tx/signing"
 	cmttypes "github.com/cometbft/cometbft/types"
 	cometbfttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -31,6 +32,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/hippocrat-dao/hippo-protocol/app"
 	"github.com/hippocrat-dao/hippo-protocol/test"
@@ -39,9 +41,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/gogoproto/proto"
 )
 
 var homeDir string
@@ -82,15 +82,17 @@ func cleanupTestEnvironment(t *testing.T, configPath string) {
 }
 
 func makeTestEncodingConfig() codec.Codec {
-	interfaceRegistry := types.NewInterfaceRegistry()
-	authtypes.RegisterInterfaces(interfaceRegistry)
-	authvesting.RegisterInterfaces(interfaceRegistry)
-	banktypes.RegisterInterfaces(interfaceRegistry)
-	govv1types.RegisterInterfaces(interfaceRegistry)
-	minttypes.RegisterInterfaces(interfaceRegistry)
-	stakingtypes.RegisterInterfaces(interfaceRegistry)
-	slashingtypes.RegisterInterfaces(interfaceRegistry)
-	distrtypes.RegisterInterfaces(interfaceRegistry)
+	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+		ProtoFiles: proto.HybridResolver,
+		SigningOptions: signing.Options{
+			AddressCodec: address.Bech32Codec{
+				Bech32Prefix: sdk.GetConfig().GetBech32AccountAddrPrefix(),
+			},
+			ValidatorAddressCodec: address.Bech32Codec{
+				Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
+			},
+		},
+	})
 
 	return codec.NewProtoCodec(interfaceRegistry)
 }


### PR DESCRIPTION
This pull request includes significant updates to the `hippod/cmd/init_test.go` file, focusing on restructuring the imports, updating the initialization command, and improving the test cases. The most important changes are summarized below:

### Restructuring Imports:
* Reorganized and updated import statements to include necessary packages from `cosmos-sdk` and removed unused imports.

### Initialization Command Updates:
* Replaced the old initialization command and related functions with a new `InitCmd` that uses `module.NewBasicManager` and supports additional modules such as `auth`, `bank`, `staking`, `mint`, `gov`, `slashing`, and `distribution`.
* Added a `makeTestEncodingConfig` function to create a codec with registered interfaces for various modules.

### Test Case Improvements:
* Updated the `TestInitCmd_Basic` test case to use the new initialization command and verify the creation of expected configuration files.
* Added a new `TestInitCmd_RecoverMnemonic_Invalid` test case to validate error handling for an invalid mnemonic phrase during initialization.
* Refactored the `TestOverrideGenesis_Valid` test case to validate the genesis state override functionality with default module genesis states. (F