### PR TITLE
test: init test cases updates with real cases for improve %

### DIFF
--- a/hippod/cmd/root_test.go
+++ b/hippod/cmd/root_test.go
@@ -1,106 +1,170 @@
 package cmd
 
 import (
-	"bytes"
 	"os"
-	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
-	"cosmossdk.io/log"
-	cmbtcfg "github.com/cometbft/cometbft/config"
-	dbm "github.com/cosmos/cosmos-db"
-	"github.com/cosmos/cosmos-sdk/server"
-	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	"github.com/hippocrat-dao/hippo-protocol/app"
+	"github.com/hippocrat-dao/hippo-protocol/types/consensus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 )
 
-func TestNewRootCmd(t *testing.T) {
-	rootCmd := NewRootCmd()
-
-	require.NotNil(t, rootCmd, "rootCmd should not be nil")
-	require.IsType(t, &cobra.Command{}, rootCmd, "rootCmd should be of type *cobra.Command")
-	require.Equal(t, "hippod", rootCmd.Use, "Command name should be 'hippod'")
-	require.NotEmpty(t, rootCmd.Commands(), "rootCmd should have subcommands")
-	require.Equal(t, "Hippo App", rootCmd.Short, "Command name should be 'hippod'")
-
-}
-
-func TestInitCometBFTConfig(t *testing.T) {
-	config := initCometBFTConfig()
-	defaultConfig := cmbtcfg.DefaultConfig()
-	require.Equal(t, config, defaultConfig)
+func makeTestEncodingConfig() codec.Codec {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	authtypes.RegisterInterfaces(interfaceRegistry)
+	sdk.RegisterInterfaces(interfaceRegistry)
+	return codec.NewProtoCodec(interfaceRegistry)
 }
 
 func TestInitAppConfig(t *testing.T) {
-	defaultConfig, _ := initAppConfig()
+	tpl, cfg := initAppConfig()
+	require.NotEmpty(t, tpl)
+	require.NotNil(t, cfg)
 
-	require.Equal(t, serverconfig.DefaultConfigTemplate, defaultConfig)
-	// add test for min gas price
+	val := reflect.ValueOf(cfg)
+	field := val.FieldByName("Config")
+	require.True(t, field.IsValid(), "Config field not found")
+
+	minGas := field.FieldByName("MinGasPrices")
+	require.True(t, minGas.IsValid(), "MinGasPrices not found")
+
+	require.Equal(t, consensus.MinGasPrices, minGas.String())
 }
 
-func TestAppExport(t *testing.T) {
-	exportedApp, err := appExport(log.NewNopLogger(), dbm.NewMemDB(), nil, 0, true, nil, simtestutil.NewAppOptionsWithFlagHome(app.DefaultNodeHome), nil)	
-	require.Error(t, err)
-	require.NotNil(t, exportedApp)
+func TestNewRootCmd(t *testing.T) {
+	rc := NewRootCmd()
+	require.NotNil(t, rc)
+	require.Equal(t, "hippod", rc.Use)
 
-	exportedApp, err = appExport(log.NewNopLogger(), dbm.NewMemDB(), nil, 0, true, nil, simtestutil.NewAppOptionsWithFlagHome(""), nil)	
-	require.Error(t, err)
-	require.NotNil(t, exportedApp)
-
-	exportedApp, err = appExport(log.NewNopLogger(), dbm.NewMemDB(), nil, -1, true, nil, simtestutil.NewAppOptionsWithFlagHome(app.DefaultNodeHome), nil)
-	require.Error(t, err)
-	require.NotNil(t, exportedApp)
-}
-
-type mockAppOptions struct {
-	options map[string]interface{}
-}
-
-func (m mockAppOptions) Get(key string) interface{} {
-	if val, ok := m.options[key]; ok {
-		return val
+	subCmds := []string{"debug", "config", "completion", "status", "genesis", "query", "tx", "keys"}
+	foundCommands := map[string]bool{}
+	for _, c := range rc.Commands() {
+		for _, name := range subCmds {
+			if c.Use == name || strings.HasPrefix(c.Use, name+" ") {
+				foundCommands[name] = true
+			}
+		}
 	}
-	return nil
+
+	for _, name := range subCmds {
+		require.True(t, foundCommands[name], "expected subcommand %s not found", name)
+	}
 }
 
-func setupGenesisFile(t *testing.T) string {
-	t.Helper()
+func TestInitCometBFTConfig(t *testing.T) {
+	cfg := initCometBFTConfig()
+	require.NotNil(t, cfg)
+	require.NotEmpty(t, cfg.DBBackend)
+}
 
-	tmpDir := t.TempDir() // return a new temp dir
-	configDir := filepath.Join(tmpDir, "config")
-	err := os.Mkdir(configDir, 0755) // create a new dir
-	require.NoError(t, err)
+func TestAddModuleInitFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "start"}
+	require.NotPanics(t, func() {
+		addModuleInitFlags(cmd)
+	})
+}
 
-	genesisPath := filepath.Join(configDir, "genesis.json")
-	err = os.WriteFile(genesisPath, []byte(`{"chain_id":"test-chain"}`), 0644) // read minimum genesis file
-	require.NoError(t, err)
+func TestGenesisCommand(t *testing.T) {
+	cdc := makeTestEncodingConfig()
+	txConfig := tx.NewTxConfig(cdc, tx.DefaultSignModes)
+	basicManager := module.NewBasicManager(
+		genutil.AppModuleBasic{},
+	)
+	customCmd := &cobra.Command{Use: "custom"}
 
-	return tmpDir
+	genCmd := genesisCommand(txConfig, basicManager, customCmd)
+	require.NotNil(t, genCmd)
+	found := false
+	for _, c := range genCmd.Commands() {
+		if c.Use == "custom" {
+			found = true
+		}
+	}
+	require.True(t, found, "custom command not found in genesis command")
+}
+
+func TestQueryCommand(t *testing.T) {
+	qc := queryCommand()
+	require.NotNil(t, qc)
+	require.Equal(t, "query", qc.Use)
+	require.Greater(t, len(qc.Commands()), 0)
+}
+
+func TestTxCommand(t *testing.T) {
+	tc := txCommand()
+	require.NotNil(t, tc)
+	require.Equal(t, "tx", tc.Use)
+	require.Greater(t, len(tc.Commands()), 0)
 }
 
 func TestNewApp(t *testing.T) {
-	logger := log.Logger(log.NewNopLogger())
-	db := dbm.NewMemDB()
-	traceStore := new(bytes.Buffer)
+	// consensus.SetWalletConfig()
+	appOpts := makeMinimalAppOptions()
+	app := newApp(log.NewNopLogger(), dbm.NewMemDB(), nil, appOpts)
+	require.NotNil(t, app)
+}
 
-	tmpHome := setupGenesisFile(t)
+// makeMinimalAppOptions returns minimal valid app options to prevent nil panic
+func makeMinimalAppOptions() fakeAppOptions {
+	_ = os.MkdirAll("/tmp/hippo-test/config", 0755)
+	_ = os.WriteFile("/tmp/hippo-test/config/genesis.json", []byte(`{"genesis_time":"2023-01-01T00:00:00Z","chain_id":"test-chain","app_state":{}}`), 0644)
 
-	appOpts := mockAppOptions{
-		options: map[string]interface{}{
-			"home":                     tmpHome,
-			server.FlagPruning:         "nothing",    // or "default" / "everything" / "nothing"
-			server.FlagMinGasPrices:    "0.001uatom", // minimum gas fees
-			server.FlagHaltHeight:      uint64(0),    // no automatic halt
-			server.FlagHaltTime:        uint64(0),
-			server.FlagInterBlockCache: true,
-			server.FlagIndexEvents:     []string{"tx.height", "tx.hash"},
-			server.FlagIAVLCacheSize:   781250, // size of the IAVL cache
-		},
+	return fakeAppOptions{
+		"home":               "/tmp/hippo-test",
+		"trace":              false,
+		"inv-check-period":   uint(1),
+		"pruning":            "default",
+		"minimum-gas-prices": "0stake",
 	}
+}
 
-	appInstance := newApp(logger, db, traceStore, appOpts)
-	require.NotNil(t, appInstance, "Should not be nil")
+func TestAppExport_InvalidHome(t *testing.T) {
+	_, err := appExport(log.NewNopLogger(), nil, nil, -1, true, nil, fakeAppOptions{"home": nil}, nil)
+	require.Error(t, err)
+	require.Equal(t, "application home not set", err.Error())
+}
+
+func TestAppExport_InvalidViper(t *testing.T) {
+	_, err := appExport(log.NewNopLogger(), nil, nil, -1, true, nil, fakeAppOptions{"home": "home"}, nil)
+	require.Error(t, err)
+	require.Equal(t, "appOpts is not viper.Viper", err.Error())
+}
+
+// Helper to mock servertypes.AppOptions
+
+type fakeAppOptions map[string]interface{}
+
+func (f fakeAppOptions) Get(key string) interface{} {
+	return f[key]
+}
+
+func TestOverwriteFlagDefaults(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	child := &cobra.Command{Use: "child"}
+	cmd.AddCommand(child)
+
+	cmd.PersistentFlags().String("chain-id", "", "")
+	cmd.PersistentFlags().String("keyring-backend", "", "")
+	cmd.Flags().String("chain-id", "", "")
+	cmd.Flags().String("keyring-backend", "", "")
+
+	require.NotPanics(t, func() {
+		overwriteFlagDefaults(cmd, map[string]string{
+			"chain-id":        "hippo-test",
+			"keyring-backend": "test",
+		})
+	})
 }


### PR DESCRIPTION
This pull request includes significant updates to the `hippod/cmd/root_test.go` file, focusing on enhancing the test coverage and refactoring the code for better maintainability. The most important changes include the addition of new test functions, the introduction of helper functions, and the reorganization of imports.

### Enhancements to test coverage:

* Added new test functions: `TestInitAppConfig`, `TestNewRootCmd`, `TestInitCometBFTConfig`, `TestAddModuleInitFlags`, `TestGenesisCommand`, `TestQueryCommand`, `TestTxCommand`, `TestNewApp`, `TestAppExport_InvalidHome`, and `TestAppExport_InvalidViper`. These tests cover various aspects of the application configuration, command initialization, and module flag settings.

### Introduction of helper functions:

* Introduced `makeTestEncodingConfig` to create a codec for testing purposes.
* Added `makeMinimalAppOptions` to provide minimal valid app options to prevent nil panic during tests.

### Reorganization of imports:

* Reorganized and cleaned up imports by removing unused ones and adding necessary ones, such as `reflect`, `strings`, and various modules from `cosmos-sdk`.

These changes collectively improve the robustness and maintainability of the test suite for