### PR TITLE
docs: keyring backend file must be used every time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ in this testnet.
 3. `$ go run hippod/main.go keys add alice --keyring-backend file`. This command will create a new key named alice, using the file backend for secure local  
    key storage.
    Make sure to save the output, especially the generated address, as you will need it later during configuration or transactions.
-4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
+4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp --keyring-backend file`, where `key_name` is the same key name as
    before; and `1084734273380000000000000000ahp` is `amount`.
-5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1`. This will create the genesis
+5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1 --keyring-backend file`. This will create the genesis
    transaction for your new chain. Here `amount` should be at least `1000000000000000000ahp`. If you
    provide too much or too little, you will encounter an error when starting your node.
 6. Now, one person needs to create the genesis file `genesis.json` using the genesis transactions

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -19,9 +19,9 @@ in this testnet.
    two names are "hippo" and "hippo-protocol-testnet-1" here. If you want to overwrite just genesis file(not including gentx), add `--overwrite` flag.
 3. `$ go run hippod/main.go keys add alice --keyring-backend file`. This command will create a new key named alice, using the file backend for secure local key storage.
    Make sure to save the output, especially the generated address, as you will need it later during configuration or transactions.
-4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp`, where `key_name` is the same key name as
+4. `$ go run hippod/main.go genesis add-genesis-account alice 1084734273380000000000000000ahp --keyring-backend file`, where `key_name` is the same key name as
    before; and `1084734273380000000000000000ahp` is `amount`.
-5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1`. This will create the genesis
+5. `$ go run hippod/main.go genesis gentx alice 1000000000000000000ahp --chain-id hippo-protocol-testnet-1 --keyring-backend file`. This will create the genesis
    transaction for your new chain. Here `amount` should be at least `1000000000000000000ahp`. If you
    provide too much or too little, you will encounter an error when starting your node.
 6. Now, one person needs to create the genesis file `genesis.json` using the genesis transactions


### PR DESCRIPTION
`--keyring-backend file` must be included every use of wallet related.