### PR TITLE
fix: override genesis for min deposit and meta data

### DIFF
--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -284,6 +284,8 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	govGenState.Params.MaxDepositPeriod = &maxDepositPeriod
 	votingPeriod := consensus.VotingPeriod
 	govGenState.Params.VotingPeriod = &votingPeriod
+	expeditedVotingPeriod := consensus.ExpeditedVotingPeriod
+	govGenState.Params.ExpeditedVotingPeriod = &expeditedVotingPeriod
 	appState[govtypes.ModuleName] = cdc.MustMarshalJSON(&govGenState)
 
 	var slashingGenState slashingtypes.GenesisState

--- a/hippod/cmd/init.go
+++ b/hippod/cmd/init.go
@@ -24,6 +24,7 @@ import (
 	govv1types "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -218,6 +219,29 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	genDoc.ConsensusParams.Block.MaxBytes = consensus.MaxBlockSize // 4MB
 	genDoc.ConsensusParams.Block.MaxGas = consensus.MaxBlockGas    // 100 milion
 
+	var bankGenState banktypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[banktypes.ModuleName], &bankGenState); err != nil {
+		return nil, err
+	}
+
+	hpMetadata := banktypes.Metadata{
+		Name:        "Hippo", // Often the full name
+		Symbol:      "HP",    // The commonly used ticker symbol
+		Description: "The native staking token of the Hippo Protocol.",
+		DenomUnits: []*banktypes.DenomUnit{ // Note: DenomUnits is a slice of *pointers* to DenomUnit
+			{
+				Denom:    "ahp", // base unit
+				Exponent: 0,
+			},
+		},
+		Base:    "ahp", // The base denomination (exponent 0)
+		Display: "ahp", // The denomination users typically see
+	}
+
+	bankGenState.DenomMetadata = append(bankGenState.DenomMetadata, hpMetadata)
+
+	appState[banktypes.ModuleName] = cdc.MustMarshalJSON(&bankGenState)
+
 	var stakingGenState stakingtypes.GenesisState
 	if err := cdc.UnmarshalJSON(appState[stakingtypes.ModuleName], &stakingGenState); err != nil {
 		return nil, err
@@ -254,6 +278,8 @@ func overrideGenesis(cdc codec.JSONCodec, genDoc *types.GenesisDoc, appState map
 	}
 	minDepositTokens := sdk.TokensFromConsensusPower(consensus.MinDepositTokens, sdk.DefaultPowerReduction) // 50,000 HP
 	govGenState.Params.MinDeposit = sdk.Coins{sdk.NewCoin(consensus.DefaultHippoDenom, minDepositTokens)}
+	expeditedMinDepositTokens := sdk.TokensFromConsensusPower(consensus.ExpeditedMinDeposit, sdk.DefaultPowerReduction) // 100,000 HP
+	govGenState.Params.ExpeditedMinDeposit = sdk.Coins{sdk.NewCoin(consensus.DefaultHippoDenom, expeditedMinDepositTokens)}
 	maxDepositPeriod := consensus.MaxDepositPeriod // 14 days
 	govGenState.Params.MaxDepositPeriod = &maxDepositPeriod
 	votingPeriod := consensus.VotingPeriod

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -20,9 +20,10 @@ const (
 	// distr
 	CommunityTax = 92
 	// gov
-	MinDepositTokens = 50_000
-	MaxDepositPeriod = 60 * 60 * 24 * 14 * time.Second
-	VotingPeriod     = 60 * 60 * 24 * 14 * time.Second
+	MinDepositTokens    = 50_000
+	ExpeditedMinDeposit = 100_000
+	MaxDepositPeriod    = 60 * 60 * 24 * 14 * time.Second
+	VotingPeriod        = 60 * 60 * 24 * 14 * time.Second
 	// slashing
 	SignedBlocksWindow      = 10_000
 	MinSignedPerWindow      = 75

--- a/types/consensus/policy.go
+++ b/types/consensus/policy.go
@@ -20,10 +20,11 @@ const (
 	// distr
 	CommunityTax = 92
 	// gov
-	MinDepositTokens    = 50_000
-	ExpeditedMinDeposit = 100_000
-	MaxDepositPeriod    = 60 * 60 * 24 * 14 * time.Second
-	VotingPeriod        = 60 * 60 * 24 * 14 * time.Second
+	MinDepositTokens      = 50_000
+	ExpeditedMinDeposit   = 100_000
+	MaxDepositPeriod      = 60 * 60 * 24 * 14 * time.Second
+	VotingPeriod          = 60 * 60 * 24 * 14 * time.Second
+	ExpeditedVotingPeriod = 60 * 60 * 24 * 7 * time.Second
 	// slashing
 	SignedBlocksWindow      = 10_000
 	MinSignedPerWindow      = 75


### PR DESCRIPTION
- 845ee9bcf4dc9f7f6fe8f08b53d3aa9004f35e14
register metadata to fix bug regarding https://github.com/hippocrat-dao/hippo-protocol/issues/59.
- f212dc950e505cf03392351fd183d04c57e06429
set expedited min deposit which wrongly use default "stake" denom.