### PR TITLE
chore: hippo-sdk v2 mark

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hippo-sdk"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Mark hippo-sdk v2 in advance.