### PR TITLE
Add GitHub Actions workflow for SDK build and test

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,0 +1,86 @@
+name: SDK
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: SDK Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Rust / wasm-pack setup
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sdk/core/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install clang
+        run: sudo apt-get update -qq && sudo apt-get install -y clang
+
+      # Cargo build & tests
+      - name: Check code formatting
+        run: cargo fmt -- --check
+        working-directory: ./sdk/core
+
+      - name: Run cargo tests
+        run: cargo test
+        working-directory: ./sdk/core
+
+      # Wasm tests
+      - name: Run wasm-pack Node.js tests
+        run: wasm-pack test --node
+        working-directory: ./sdk/core
+
+      # SDK builds
+      - name: Build for Node.js
+        run: wasm-pack build --target=nodejs --out-dir=../js/pkg/node --out-name=core && rm ../js/pkg/node/.gitignore
+        working-directory: ./sdk/core
+
+      - name: Build for Web (Bundler)
+        run: wasm-pack build --target=bundler --out-dir=../js/pkg/bundle --out-name=core && rm ../js/pkg/bundle/.gitignore
+        working-directory: ./sdk/core
+
+      - name: Pack npm package
+        run: wasm-pack pack ../js/pkg
+        working-directory: ./sdk/core
+
+      # JS example (Node.js)
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS example dependencies
+        run: |
+          TARBALL=$(ls ../../pkg/*.tgz | head -1)
+          npm pkg set dependencies.hippo-sdk="file:$TARBALL"
+          npm install
+        working-directory: ./sdk/js/examples/nodejs
+
+      - name: Run JS example
+        run: node index.js
+        working-directory: ./sdk/js/examples/nodejs


### PR DESCRIPTION
## Add SDK CI workflow (`sdk.yml`)

Adds `.github/workflows/sdk.yml` to cover the Rust/Wasm SDK on every push and PR to `main`.

**What the workflow does:**
- Cargo fmt check, `cargo test`, and `wasm-pack test --node`
- Builds SDK for Node.js and bundler (web) targets via `wasm-pack`
- Packs the npm package with `wasm-pack pack`
- Installs the packed `.tgz` into the Node.js example and runs `node index.js` to verify the JS API works end-to-end

Closes #184 

---

### Tested Locally

[act](https://github.com/nektos/act) runs GitHub Actions locally.

<img width="1670" height="403" alt="image" src="https://github.com/user-attachments/assets/bd6810c7-a714-4cc9-acf4-0d262c79e0bc" />

<img width="1542" height="544" alt="image" src="https://github.com/user-attachments/assets/b001e0f3-b65b-4fd0-b3ce-6fa123de3a3f" />

- attaching the full test run logs

[sdk-ci-test-output.txt](https://github.com/user-attachments/files/28621800/sdk-ci-test-output.txt)
