### PR TITLE
add JS smoke test into existing 'rust' CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test_and_build:
@@ -40,34 +41,56 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # 4. Code Formatting Check
+      # 4. Install clang (required by some wasm-pack dependencies)
+      - name: Install clang
+        run: sudo apt-get update -qq && sudo apt-get install -y clang
+
+      # 5. Code Formatting Check
       # Run 'cargo fmt --check' to ensure the code adheres to style guidelines.
       # This step will fail the workflow if any files need formatting.
       - name: Check Code Formatting (cargo fmt --check)
         run: cargo fmt -- --check
         working-directory: ./sdk/core
 
-      # 5. Standard Cargo Tests
+      # 6. Standard Cargo Tests
       - name: Run Cargo Tests
         run: cargo test
         working-directory: ./sdk/core
 
-      # 6. wasm-pack Tests for Node.js environment
+      # 7. wasm-pack Tests for Node.js environment
       - name: Run wasm-pack Node.js Tests
         run: wasm-pack test --node
         working-directory: ./sdk/core
 
-      # 7. Build for nodejs
+      # 8. Build for nodejs
       - name: Build for Node.js
         run: wasm-pack build --target=nodejs --out-dir=../js/pkg/node --out-name=core && rm ../js/pkg/node/.gitignore
         working-directory: ./sdk/core
 
-      # 8. Build for web (bundler target)
+      # 9. Build for web (bundler target)
       - name: Build for Web (Bundler)
         run: wasm-pack build --target=bundler --out-dir=../js/pkg/bundle --out-name=core && rm ../js/pkg/bundle/.gitignore
         working-directory: ./sdk/core
 
-      # 9. Package for npm
+      # 10. Package for npm
       - name: Package for NPM
         run: wasm-pack pack ../js/pkg
         working-directory: ./sdk/core
+
+      # 11. JS example smoke test — installs the packed .tgz into the real consumer
+      #     project and runs it, catching packaging/export issues wasm-pack pack alone won't surface.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS example dependencies
+        run: |
+          TARBALL=$(ls ../../pkg/*.tgz | head -1)
+          npm pkg set dependencies.hippo-sdk="file:$TARBALL"
+          npm install
+        working-directory: ./sdk/js/examples/nodejs
+
+      - name: Run JS example
+        run: node index.js
+        working-directory: ./sdk/js/examples/nodejs

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -30,3 +30,6 @@ opt-level = "s"
 lto = true
 strip = true
 codegen-units = 1
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]


### PR DESCRIPTION
## Extend [rust.yml](https://github.com/hippo-protocol/hippo-protocol/blob/main/.github/workflows/rust.yml) with JS example smoke test

Rather than adding a separate [sdk.yml](https://github.com/hippo-protocol/hippo-protocol/pull/208) workflow, this extends the existing `.github/workflows/rust.yml` with the missing pieces to avoid duplication.

**Changes to `rust.yml`:**

- Add `workflow_dispatch` trigger to allow manual runs from the GitHub Actions UI
- Add `Install clang` step before the formatting check (required by some wasm-pack dependencies; was missing from this workflow earlier)
- Append three new steps for the JS example smoke test:
  - **Setup Node.js 20** via `actions/setup-node@v4`
  - **Install JS example dependencies** — finds the packed `.tgz` from `wasm-pack pack`, injects it as a local `file:` dependency into `sdk/js/examples/nodejs`, and runs `npm install`
  - **Run JS example** — executes `node index.js` to verify the built package exports work in a real consumer project

> The smoke test is the one piece that was not already covered by `rust.yml`. It catches packaging and export issues that `wasm-pack pack` alone won't surface.

Closes #184 

---

### Tested Locally:

I've tested the updated workflow with [act](https://github.com/nektos/act) locally and attaching the full output as the [rust-ci-test-output.txt](https://github.com/user-attachments/files/29073966/rust-ci-test-output.txt) file and final output screenshot image:

<img width="1269" height="640" alt="image" src="https://github.com/user-attachments/assets/b6692b50-2a96-45e0-832a-af91c6a03043" />