### PR TITLE
release ci workflow implementation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 100
+    env:
+      TM_VERSION: v0.38.21
+      COSMWASM_VERSION: v2.2.4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run GoReleaser Cross
+        run: |
+          docker run \
+            --rm \
+            -e CGO_ENABLED=1 \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e TM_VERSION="${TM_VERSION}" \
+            -e COSMWASM_VERSION="${COSMWASM_VERSION}" \
+            -v "$(pwd):/go/src/hippod" \
+            -w /go/src/hippod \
+            ghcr.io/goreleaser/goreleaser-cross:v1.24 \
+            release --clean --timeout=90m

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,8 +130,10 @@ checksum:
     algorithm: sha256
 
 changelog:
-    disable: true
+    use: github
 
 release:
-    prerelease: true
+    prerelease: auto
     name_template: "v{{.Version}}"
+
+# To trigger a release: git tag v2.0.3 && git push origin v2.0.3


### PR DESCRIPTION
## Summary

Closes #207 

1. Created `.github/workflows/release.yml`  using the goreleaser-cross Docker image (same pattern as [Makefile's ci-release](https://github.com/hippo-protocol/hippo-protocol/blob/14c48ebd6e92f1a87ac2548f32fd81b7ba48f452/Makefile#L206))
2. Updated `.goreleaser.yaml` to enable GitHub's auto-generated release notes and set prerelease: auto

---

**Workflow**:

- Triggers on push to any tag matching `v*.*.*` and also can be `manually triggered` 
- permissions: contents: write — required for goreleaser to create the GitHub Release and upload assets
- fetch-depth: 0 — fetches full git history and all tags so goreleaser can find the previous tag to generate the Full Changelog link 
- Runs the same `goreleaser-cross:v1.24` Docker image already used in `make ci-release`, so all cross-compilation toolchains and CosmWasm static libs are available without any extra setup
- Passes `GITHUB_TOKEN` into the container so goreleaser can create the release
- `--timeout=90m` matches the timeout already set in the `Makefile`
- The artifact names, checksum file, and binary targets were already correct in .goreleaser.yaml — no changes needed there.

---

**Test**

- tested in replica repository: [hippo-protocol-release-test](https://github.com/afa-farkhod/hippo-protocol-release-test)
- test run of [git actions](https://github.com/afa-farkhod/hippo-protocol-release-test/actions)

<img width="1468" height="399" alt="image" src="https://github.com/user-attachments/assets/e0789d84-276d-404d-a97f-105f080ce6c2" />

- [release page](https://github.com/afa-farkhod/hippo-protocol-release-test/releases) as the output of the previous git action run

<img width="1176" height="810" alt="image" src="https://github.com/user-attachments/assets/7f2ea437-ac55-4306-9eaf-a37193a78933" />